### PR TITLE
Add onRegister for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,20 @@ app.use(second, func)
 
 This is useful in cases where an injected variable from a plugin needs to be made available to another.
 
+If the meta data of a plugin contain a `onRegister(server, opts)` function, it will be executed synchronous before the plugin is being loaded: 
+
+```js
+async function plugin (app, opts) {
+  console.log(opts.list)
+})
+plugin[Symbol.for('plugin-meta')] = {
+  onRegister (app, opts) {  // this is a sync function, no callback and no promise
+    opts.list = ['foo', 'bar']
+  }
+}
+app.use(plugin)
+```
+
 -------------------------------------------------------
 <a name="error-handling"></a>
 #### Error handling

--- a/boot.js
+++ b/boot.js
@@ -200,6 +200,11 @@ Boot.prototype._addPlugin = function (plugin, opts, isAfter) {
     throw new Error('root plugin has already booted')
   }
 
+  const pluginMeta = plugin[Symbol.for('plugin-meta')]
+  if (pluginMeta && typeof pluginMeta.onRegister === 'function') {
+    pluginMeta.onRegister(this._server, opts)
+  }
+
   // we always add plugins to load at the current element
   const current = this._current[0]
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -355,9 +355,10 @@ test('boot a promise plugin with onRegister', (t) => {
     hello: 'world'
   }
 
-  async function plugin (s, opts) {
+  function plugin (s, opts) {
     t.equal(s, server, 'the first argument is the server')
     t.deepEqual(opts, myOpts, 'passed options')
+    return Promise.resolve()
   }
   plugin[Symbol.for('plugin-meta')] = {
     onRegister (app, opts) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -371,4 +371,3 @@ test('boot a promise plugin with onRegister', (t) => {
     t.pass('booted')
   })
 })
-

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -318,3 +318,30 @@ test('throws correctly if registering after ready', (t) => {
     }, 'root plugin has already booted')
   })
 })
+
+test('boot a plugin with onRegister', (t) => {
+  t.plan(5)
+
+  const server = {}
+  const app = boot(server)
+  const myOpts = {
+    hello: 'world'
+  }
+
+  function plugin (s, opts, done) {
+    t.equal(s, server, 'the first argument is the server')
+    t.deepEqual(opts, myOpts, 'passed options')
+    done()
+  }
+  plugin[Symbol.for('plugin-meta')] = {
+    onRegister (app, opts) {
+      t.equal(app, server, 'the first argument is the server')
+      t.deepEqual(opts, myOpts, 'passed options')
+    }
+  }
+  app.use(plugin, myOpts)
+
+  app.on('start', () => {
+    t.pass('booted')
+  })
+})

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -345,3 +345,30 @@ test('boot a plugin with onRegister', (t) => {
     t.pass('booted')
   })
 })
+
+test('boot a promise plugin with onRegister', (t) => {
+  t.plan(5)
+
+  const server = {}
+  const app = boot(server)
+  const myOpts = {
+    hello: 'world'
+  }
+
+  async function plugin (s, opts) {
+    t.equal(s, server, 'the first argument is the server')
+    t.deepEqual(opts, myOpts, 'passed options')
+  }
+  plugin[Symbol.for('plugin-meta')] = {
+    onRegister (app, opts) {
+      t.equal(app, server, 'the first argument is the server')
+      t.deepEqual(opts, myOpts, 'passed options')
+    }
+  }
+  app.use(plugin, myOpts)
+
+  app.on('start', () => {
+    t.pass('booted')
+  })
+})
+


### PR DESCRIPTION
As discussed in fastify/fastify#1812 this adds support for an optional `onRegister` function that can be called synchronously before a plugin is loaded.