### PR TITLE
ready:Promise should return the server instance

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -329,11 +329,20 @@ Boot.prototype.ready = function (func) {
     this._readyQ.push(readyPromiseCB)
     this.start()
 
+    /**
+     * The `encapsulateThreeParam` let callback function
+     * bind to the right server instance.
+     * In promises we need to track the last server
+     * instance loaded, the first one in the _current queue.
+     */
+    const relativeContext = this._current[0].server
+
     function readyPromiseCB (err, context, done) {
+      // the context is always binded to the root server
       if (err) {
         reject(err)
       } else {
-        resolve(context)
+        resolve(relativeContext)
       }
       process.nextTick(done)
     }

--- a/test/after-and-ready.test.js
+++ b/test/after-and-ready.test.js
@@ -196,6 +196,57 @@ test('if the after/ready callback has two parameters, the first one must be the 
   })
 })
 
+test('if the after/ready async, the returns must be the context generated', (t) => {
+  t.plan(3)
+
+  const server = { my: 'server', index: 0 }
+  const app = boot(server)
+  app.override = function (old) {
+    return { ...old, index: old.index + 1 }
+  }
+
+  app.use(function (s, opts, done) {
+    s.use(function (s, opts, done) {
+      s.ready().then(itself => t.deepEqual(itself, s, 'deep deep'))
+      done()
+    })
+    s.ready().then(itself => t.deepEqual(itself, s, 'deep'))
+    done()
+  })
+
+  app.ready().then(itself => t.deepEqual(itself, server, 'outer'))
+})
+
+test('if the after/ready callback, the returns must be the context generated', (t) => {
+  t.plan(3)
+
+  const server = { my: 'server', index: 0 }
+  const app = boot(server)
+  app.override = function (old) {
+    return { ...old, index: old.index + 1 }
+  }
+
+  app.use(function (s, opts, done) {
+    s.use(function (s, opts, done) {
+      s.ready((_, itself, done) => {
+        t.deepEqual(itself, s, 'deep deep')
+        done()
+      })
+      done()
+    })
+    s.ready((_, itself, done) => {
+      t.deepEqual(itself, s, 'deep')
+      done()
+    })
+    done()
+  })
+
+  app.ready((_, itself, done) => {
+    t.deepEqual(itself, server, 'outer')
+    done()
+  })
+})
+
 test('error should come in the first after - one parameter', (t) => {
   t.plan(3)
 


### PR DESCRIPTION
The `ready()` interface return a `Promise<server>` that return always the root server.

I have added the tests:
- with callback style all is fine
- with promise style, the issue shows


Blocking this PR https://github.com/fastify/fastify/pull/2361

