### PR TITLE
Registering plugins inside after should trigger override

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -81,6 +81,8 @@ Plugin.prototype.exec = function (server, cb) {
       debug('override errored', name)
       return cb(err)
     }
+  } else {
+    this.server = server
   }
 
   this.opts = typeof this.opts === 'function' ? this.opts(this.server) : this.opts

--- a/test/override.test.js
+++ b/test/override.test.js
@@ -340,3 +340,35 @@ test('after trigger override', t => {
       t.equals(overrideCalls, 1, 'async after with 2 parameters should not trigger override')
     })
 })
+
+test('custom inheritance override in after', (t) => {
+  t.plan(6)
+
+  const server = { count: 0 }
+  const app = boot(server)
+
+  app.override = function (s) {
+    const res = Object.create(s)
+    res.count = res.count + 1
+
+    return res
+  }
+
+  app.use(function first (s1, opts, cb) {
+    t.notEqual(s1, server)
+    t.ok(server.isPrototypeOf(s1))
+    t.equal(s1.count, 1)
+    s1.after(() => {
+      s1.use(second)
+    })
+
+    cb()
+
+    function second (s2, opts, cb) {
+      t.notEqual(s2, s1)
+      t.ok(s1.isPrototypeOf(s2))
+      t.equal(s2.count, 2)
+      cb()
+    }
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/2406

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
