### PR TITLE
Support faux modules

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -191,9 +191,15 @@ Boot.prototype.override = function (server, func, opts) {
 }
 
 function assertPlugin (plugin) {
+  // Faux modules are modules built with TypeScript
+  // or Babel that they export a .default property.
+  if (plugin && typeof plugin === 'object' && typeof plugin.default === 'function') {
+    plugin = plugin.default
+  }
   if (!(plugin && (typeof plugin === 'function' || typeof plugin.then === 'function'))) {
     throw new Error('plugin must be a function or a promise')
   }
+  return plugin
 }
 
 Boot.prototype[kAvvio] = true
@@ -224,7 +230,7 @@ Boot.prototype._loadRegistered = function () {
 Object.defineProperty(Boot.prototype, 'then', { get: thenify })
 
 Boot.prototype._addPlugin = function (plugin, opts, isAfter) {
-  assertPlugin(plugin)
+  plugin = assertPlugin(plugin)
   opts = opts || {}
 
   if (this.booted) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -372,3 +372,27 @@ test('preReady errors do not override plugin\'s errors', (t) => {
     t.equal(err.message, 'baam')
   })
 })
+
+test('support faux modules', (t) => {
+  t.plan(4)
+
+  const app = boot()
+  var after = false
+
+  // Faux modules are modules built with TypeScript
+  // or Babel that they export a .default property.
+  app.use({
+    default: function (server, opts, done) {
+      t.equal(server, app, 'the first argument is the server')
+      t.deepEqual(opts, {}, 'no options')
+      t.ok(after, 'delayed execution')
+      done()
+    }
+  })
+
+  after = true
+
+  app.on('start', () => {
+    t.pass('booted')
+  })
+})


### PR DESCRIPTION
This is one of those changes that I would prefer not to put in. However I think it would improve the development experience for TypeScript and babel users that have problem with "faux modules" (esm syntax transplied to cjs).

I think it can help resolving https://github.com/fastify/fastify/issues/2404.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
