### PR TITLE
Better error message for ERR_AVVIO_PLUGIN_TIMEOUT

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -436,7 +436,7 @@ function timeoutCall (func, rootErr, context, cb) {
   let timer = setTimeout(() => {
     debug('timed out', name)
     timer = null
-    const toutErr = new Error(`ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: ${name}`)
+    const toutErr = new Error(`ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: ${name}. You may have forgotten to call 'done' function`)
     toutErr.code = 'ERR_AVVIO_READY_TIMEOUT'
     toutErr.fn = func
     this._error = toutErr

--- a/boot.js
+++ b/boot.js
@@ -436,7 +436,7 @@ function timeoutCall (func, rootErr, context, cb) {
   let timer = setTimeout(() => {
     debug('timed out', name)
     timer = null
-    const toutErr = new Error(`ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: ${name}. You may have forgotten to call 'done' function`)
+    const toutErr = new Error(`ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: ${name}. You may have forgotten to call 'done' function or to resolve a Promise`)
     toutErr.code = 'ERR_AVVIO_READY_TIMEOUT'
     toutErr.fn = func
     this._error = toutErr

--- a/plugin.js
+++ b/plugin.js
@@ -119,7 +119,7 @@ Plugin.prototype.exec = function (server, cb) {
     timer = setTimeout(function () {
       debug('timed out', name)
       timer = null
-      const err = new Error(`${CODE_PLUGIN_TIMEOUT}: plugin did not start in time: ${name}`)
+      const err = new Error(`${CODE_PLUGIN_TIMEOUT}: plugin did not start in time: ${name}. You may have forgotten to call 'done' function`)
       err.code = CODE_PLUGIN_TIMEOUT
       err.fn = func
       done(err)

--- a/plugin.js
+++ b/plugin.js
@@ -119,7 +119,7 @@ Plugin.prototype.exec = function (server, cb) {
     timer = setTimeout(function () {
       debug('timed out', name)
       timer = null
-      const err = new Error(`${CODE_PLUGIN_TIMEOUT}: plugin did not start in time: ${name}. You may have forgotten to call 'done' function`)
+      const err = new Error(`${CODE_PLUGIN_TIMEOUT}: plugin did not start in time: ${name}. You may have forgotten to call 'done' function or to resolve a Promise`)
       err.code = CODE_PLUGIN_TIMEOUT
       err.fn = func
       done(err)

--- a/test/plugin-timeout.test.js
+++ b/test/plugin-timeout.test.js
@@ -4,6 +4,8 @@ const t = require('tap')
 const test = t.test
 const boot = require('..')
 
+const message = (code, name) => `${code}: plugin did not start in time: ${name}. You may have forgotten to call 'done' function or to resolve a Promise`
+
 test('timeout without calling next - callbacks', (t) => {
   t.plan(4)
   const app = boot({}, {
@@ -16,7 +18,7 @@ test('timeout without calling next - callbacks', (t) => {
   app.ready((err) => {
     t.ok(err)
     t.strictEqual(err.fn, one)
-    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: one. You may have forgotten to call \'done\' function')
+    t.strictEqual(err.message, message('ERR_AVVIO_PLUGIN_TIMEOUT', 'one'))
     t.strictEqual(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
 })
@@ -35,7 +37,7 @@ test('timeout without calling next - promises', (t) => {
   app.ready((err) => {
     t.ok(err)
     t.strictEqual(err.fn, two)
-    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: two. You may have forgotten to call \'done\' function')
+    t.strictEqual(err.message, message('ERR_AVVIO_PLUGIN_TIMEOUT', 'two'))
     t.strictEqual(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
 })
@@ -48,7 +50,7 @@ test('timeout without calling next - use file as name', (t) => {
   app.use(require('./fixtures/plugin-no-next'))
   app.ready((err) => {
     t.ok(err)
-    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: ' + require.resolve('./fixtures/plugin-no-next') + '. You may have forgotten to call \'done\' function')
+    t.strictEqual(err.message, message('ERR_AVVIO_PLUGIN_TIMEOUT', require.resolve('./fixtures/plugin-no-next')))
     t.strictEqual(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
 })
@@ -64,7 +66,7 @@ test('timeout without calling next - use code as name', (t) => {
 
   app.ready((err) => {
     t.ok(err)
-    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: function (app, opts, next) { -- // do not call next on purpose - code as name. You may have forgotten to call \'done\' function')
+    t.strictEqual(err.message, message('ERR_AVVIO_PLUGIN_TIMEOUT', 'function (app, opts, next) { -- // do not call next on purpose - code as name'))
     t.strictEqual(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
 })
@@ -145,7 +147,7 @@ test('timeout without calling next in ready and ignoring the error', (t) => {
 
   app.ready(function onReadyTwo (err) {
     t.ok(err)
-    t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone. You may have forgotten to call \'done\' function')
+    t.strictEqual(err.message, message('ERR_AVVIO_READY_TIMEOUT', 'onReadyWithoutDone'))
     t.strictEqual(err.code, 'ERR_AVVIO_READY_TIMEOUT')
     // don't rethrow the error
   })
@@ -164,7 +166,7 @@ test('timeout without calling next in ready and rethrowing the error', (t) => {
     t.pass('loaded')
     app.ready(function readyOk (err, done) {
       t.ok(err)
-      t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone. You may have forgotten to call \'done\' function')
+      t.strictEqual(err.message, message('ERR_AVVIO_READY_TIMEOUT', 'onReadyWithoutDone'))
       t.strictEqual(err.code, 'ERR_AVVIO_READY_TIMEOUT')
       done(err)
     })
@@ -187,7 +189,7 @@ test('timeout without calling next in ready and rethrowing the error', (t) => {
 
   app.ready(function onReadyTwo (err, done) {
     t.ok(err)
-    t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone. You may have forgotten to call \'done\' function')
+    t.strictEqual(err.message, message('ERR_AVVIO_READY_TIMEOUT', 'onReadyWithoutDone'))
     t.strictEqual(err.code, 'ERR_AVVIO_READY_TIMEOUT')
     done(err)
   })

--- a/test/plugin-timeout.test.js
+++ b/test/plugin-timeout.test.js
@@ -16,7 +16,7 @@ test('timeout without calling next - callbacks', (t) => {
   app.ready((err) => {
     t.ok(err)
     t.strictEqual(err.fn, one)
-    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: one')
+    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: one. You may have forgotten to call \'done\' function')
     t.strictEqual(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
 })
@@ -35,7 +35,7 @@ test('timeout without calling next - promises', (t) => {
   app.ready((err) => {
     t.ok(err)
     t.strictEqual(err.fn, two)
-    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: two')
+    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: two. You may have forgotten to call \'done\' function')
     t.strictEqual(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
 })
@@ -48,7 +48,7 @@ test('timeout without calling next - use file as name', (t) => {
   app.use(require('./fixtures/plugin-no-next'))
   app.ready((err) => {
     t.ok(err)
-    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: ' + require.resolve('./fixtures/plugin-no-next'))
+    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: ' + require.resolve('./fixtures/plugin-no-next') + '. You may have forgotten to call \'done\' function')
     t.strictEqual(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
 })
@@ -64,7 +64,7 @@ test('timeout without calling next - use code as name', (t) => {
 
   app.ready((err) => {
     t.ok(err)
-    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: function (app, opts, next) { -- // do not call next on purpose - code as name')
+    t.strictEqual(err.message, 'ERR_AVVIO_PLUGIN_TIMEOUT: plugin did not start in time: function (app, opts, next) { -- // do not call next on purpose - code as name. You may have forgotten to call \'done\' function')
     t.strictEqual(err.code, 'ERR_AVVIO_PLUGIN_TIMEOUT')
   })
 })
@@ -145,7 +145,7 @@ test('timeout without calling next in ready and ignoring the error', (t) => {
 
   app.ready(function onReadyTwo (err) {
     t.ok(err)
-    t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone')
+    t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone. You may have forgotten to call \'done\' function')
     t.strictEqual(err.code, 'ERR_AVVIO_READY_TIMEOUT')
     // don't rethrow the error
   })
@@ -164,7 +164,7 @@ test('timeout without calling next in ready and rethrowing the error', (t) => {
     t.pass('loaded')
     app.ready(function readyOk (err, done) {
       t.ok(err)
-      t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone')
+      t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone. You may have forgotten to call \'done\' function')
       t.strictEqual(err.code, 'ERR_AVVIO_READY_TIMEOUT')
       done(err)
     })
@@ -187,7 +187,7 @@ test('timeout without calling next in ready and rethrowing the error', (t) => {
 
   app.ready(function onReadyTwo (err, done) {
     t.ok(err)
-    t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone')
+    t.strictEqual(err.message, 'ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: onReadyWithoutDone. You may have forgotten to call \'done\' function')
     t.strictEqual(err.code, 'ERR_AVVIO_READY_TIMEOUT')
     done(err)
   })


### PR DESCRIPTION
Just because this has happened to me many times :-) 
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
