### PR TITLE
fix typescript declaration for app.use with async functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare namespace avvio {
   }
 
   interface Plugin<O, I> {
-    (server: context<I>, options: O, done: (err?: Error) => void): void;
+    (server: context<I>, options: O, done: (err?: Error) => void): unknown;
   }
 
   interface Server<I> {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -369,3 +369,10 @@ import * as avvio from "../../";
   // avvio with server, options and done callback
   const app = avvio(server, options, () => undefined);
 }
+
+{
+  const app = avvio();
+  const plugin: avvio.Plugin<any, any> = async (): Promise<void> => {};
+  const promise = plugin(app, {}, undefined as any);
+  (promise instanceof Promise);
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
   - `npm run benchmark` fails with `missing script: benchmark`
- [x] tests and/or benchmarks are included
     - not relevant
- [x] documentation is changed or added
    - not relevant
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Btw, the test fails with an `listen EADDRINUSE: address already in use :::3000` if there is something else listening on port `3000` where the tests is run.