### PR TITLE
Use fastify plugin metadata or an explicit passed in name option for a plugin's name

### DIFF
--- a/test/fixtures/plugin-no-next.js
+++ b/test/fixtures/plugin-no-next.js
@@ -1,5 +1,5 @@
 'use strict'
 
-module.exports = function (app, opts, next) {
+module.exports = function noNext (app, opts, next) {
   // no call to next
 }

--- a/test/plugin-name.test.js
+++ b/test/plugin-name.test.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const boot = require('..')
+
+test('plugins get a name from the plugin metadata if it is set', async (t) => {
+  t.plan(1)
+  const app = boot()
+
+  const func = (app, opts, next) => next()
+  func[Symbol.for('plugin-meta')] = { name: 'a-test-plugin' }
+  app.use(func)
+  await app.ready()
+
+  t.match(app.toJSON(), {
+    label: 'bound root',
+    nodes: [
+      { label: 'a-test-plugin' }
+    ]
+  })
+})
+
+test('plugins get a name from the options if theres no metadata', async (t) => {
+  t.plan(1)
+  const app = boot()
+
+  function testPlugin (app, opts, next) { next() }
+  app.use(testPlugin, { name: 'test registration options name' })
+  await app.ready()
+
+  t.match(app.toJSON(), {
+    label: 'bound root',
+    nodes: [
+      { label: 'test registration options name' }
+    ]
+  })
+})
+
+test('plugins get a name from the function name if theres no name in the options and no metadata', async (t) => {
+  t.plan(1)
+  const app = boot()
+
+  function testPlugin (app, opts, next) { next() }
+  app.use(testPlugin)
+  await app.ready()
+
+  t.match(app.toJSON(), {
+    label: 'bound root',
+    nodes: [
+      { label: 'testPlugin' }
+    ]
+  })
+})
+
+test('plugins get a name from the function source if theres no other option', async (t) => {
+  t.plan(1)
+  const app = boot()
+
+  app.use((app, opts, next) => next())
+  await app.ready()
+
+  t.match(app.toJSON(), {
+    label: 'bound root',
+    nodes: [
+      { label: '(app, opts, next) => next()' }
+    ]
+  })
+})

--- a/test/plugin-timeout.test.js
+++ b/test/plugin-timeout.test.js
@@ -50,7 +50,7 @@ test('timeout without calling next - use file as name', (t) => {
   app.use(require('./fixtures/plugin-no-next'))
   app.ready((err) => {
     t.ok(err)
-    t.equal(err.message, message(require.resolve('./fixtures/plugin-no-next')))
+    t.equal(err.message, message('noNext'))
     t.equal(err.code, 'AVV_ERR_READY_TIMEOUT')
   })
 })


### PR DESCRIPTION
This is a second approach to the same thing in #140.

`getName` in avvio gets a string name for each plugin registered to use when reporting debug info. Doing some profiling of a big fastify application, I noticed that a lot of time was spent getting the name of avvio plugins in the `getName` function. For me, `require.cache` was very big, and the number of registered plugins was very big, so the O(n^2) search for each file in the require cache was actually taking a good long while. Also, `getName` relying on the require cache is undesirable as ESM becomes more and more common -- we should try to move to an approach that doesn't need that.

Fortunately, a lot of plugins registered with avvio already report their names! We were somewhat accidentally using `getName` to get the name of a lot of plugins that already have fastify metadata set, or pass an explicit name in with their options. We can avoid the nasty performance pitfall by just accepting the incoming names inside avvio, and then falling back on one of the much faster last-resort strategies if plugin names aren't set.

It is kind of unfortunate that we can't use the plugin's file path as a nice, human friendly name for a plugin that isn't otherwise named, but I think the performance issue merits its removal, and I will add documentation to fastify to indicate that naming your own plugins is a good idea.

I tried running the fastify test suite with this version of this library in place, and the only things that failed were like this:

```
  --- expected
  +++ actual
  @@ -1,1 +1,1 @@
  -ERR_AVVIO_READY_TIMEOUT
  +AVV_ERR_READY_TIMEOUT
```

which I think is from other changes to `avvio` master, not this change. 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
