### PR TITLE
fix: delay plugin promise resolution until next tick

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -149,16 +149,18 @@ Plugin.prototype.loadedSoFar = function () {
       this._error = err
       this.q.pause()
 
-      if (err) {
-        debug('rejecting promise', this.name, err)
-        this._promise.reject(err)
-      } else {
-        debug('resolving promise', this.name)
-        this._promise.resolve()
-      }
-      this._promise = null
+      process.nextTick(() => {
+        if (err) {
+          debug('rejecting promise', this.name, err)
+          this._promise.reject(err)
+        } else {
+          debug('resolving promise', this.name)
+          this._promise.resolve()
+        }
+        this._promise = null
 
-      process.nextTick(cb, err)
+        process.nextTick(cb, err)
+      })
     })
     this.q.resume()
   }

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const boot = require('..')
 const { promisify } = require('util')
 const sleep = promisify(setTimeout)
-const fs = require('fs/promises')
+const fs = require('fs').promises
 const path = require('path')
 
 test('await after - nested plugins with same tick callbacks', async (t) => {

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -247,7 +247,7 @@ test('await after complex scenario', async (t) => {
   t.notOk(fourthLoaded, 'fourth is not loaded')
   app.use(second)
   t.ok(firstLoaded, 'first is loaded')
-  t.notOk(secondLoaded, 'second is not loaded')
+  t.ok(secondLoaded, 'second is loaded')
   t.notOk(thirdLoaded, 'third is not loaded')
   t.notOk(fourthLoaded, 'fourth is not loaded')
   app.use(third)
@@ -277,6 +277,54 @@ test('await after complex scenario', async (t) => {
 
   async function fourth () {
     fourthLoaded = true
+  }
+})
+
+test('without autostart and sync/async plugin mix', async (t) => {
+  const app = {}
+  boot(app, { autostart: false })
+  t.plan(9)
+
+  let firstLoaded = false
+  let secondLoaded = false
+  let thirdLoaded = false
+
+  app.use(first)
+  await app.after()
+  t.ok(firstLoaded, 'first is loaded')
+  t.notOk(secondLoaded, 'second is not loaded')
+  t.notOk(thirdLoaded, 'third is not loaded')
+
+  await sleep(10)
+
+  app.use(second)
+  await app.after()
+  t.ok(firstLoaded, 'first is loaded')
+  t.ok(secondLoaded, 'second is loaded')
+  t.notOk(thirdLoaded, 'third is not loaded')
+
+  await sleep(10)
+
+  app.use(third)
+  await app.after()
+  t.ok(firstLoaded, 'first is loaded')
+  t.ok(secondLoaded, 'second is loaded')
+  t.ok(thirdLoaded, 'third is loaded')
+
+  await app.ready()
+
+  async function first () {
+    firstLoaded = true
+  }
+
+  async function second () {
+    await sleep(10)
+    secondLoaded = true
+  }
+
+  async function third (app) {
+    await sleep(10)
+    thirdLoaded = true
   }
 })
 

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -4,6 +4,8 @@ const { test } = require('tap')
 const boot = require('..')
 const { promisify } = require('util')
 const sleep = promisify(setTimeout)
+const fs = require('fs/promises')
+const path = require('path')
 
 test('await after - nested plugins with same tick callbacks', async (t) => {
   const app = {}
@@ -283,7 +285,7 @@ test('await after complex scenario', async (t) => {
 test('without autostart and sync/async plugin mix', async (t) => {
   const app = {}
   boot(app, { autostart: false })
-  t.plan(9)
+  t.plan(11)
 
   let firstLoaded = false
   let secondLoaded = false
@@ -295,7 +297,8 @@ test('without autostart and sync/async plugin mix', async (t) => {
   t.notOk(secondLoaded, 'second is not loaded')
   t.notOk(thirdLoaded, 'third is not loaded')
 
-  await sleep(10)
+  const contents = await fs.readFile(path.join(__dirname, 'fixtures', 'dummy.txt'), 'utf-8')
+  t.equal(contents, 'hello, world!')
 
   app.use(second)
   await app.after()
@@ -318,7 +321,8 @@ test('without autostart and sync/async plugin mix', async (t) => {
   }
 
   async function second () {
-    await sleep(10)
+    const contents = await fs.readFile(path.join(__dirname, 'fixtures', 'dummy.txt'), 'utf-8')
+    t.equal(contents, 'hello, world!')
     secondLoaded = true
   }
 

--- a/test/fixtures/dummy.txt
+++ b/test/fixtures/dummy.txt
@@ -1,0 +1,1 @@
+hello, world!


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Description
This PR proposes a fix for the plugin registration race condition we're seeing in this `fastify` issue :

https://github.com/fastify/fastify/issues/3726

The TL;DR; is that it appears the use of a top-level `await` between some (but not all) plugin registrations can get `avvio`'s root plugin into a weird state where it resolves an `after()` promise prior to in-flight registration functions having completed.  The issue doesn't occur if a top-level `await` statement exists between either ALL plugins or NONE of them.

I compared the `DEBUG=avvio` output between a "bad" boot sequence (e.g., what's in the [sample repo](https://github.com/chrskrchr/fastify-plugin-race-condition))  and "good" boot sequence (top-level `await` statements between all plugins) and it appears the issue in the "bad" boot sequence stems from plugin0's `_after` promise being resolved after the plugin1 has started initializing:
 
<img width="1541" alt="Screen Shot 2022-02-24 at 12 31 01 PM" src="https://user-images.githubusercontent.com/805780/155590967-0fb2e18c-ac13-48ec-aea1-a9567258657e.png">

This PR proposes a fix where a plugin's promise resolution is always delayed until `process.nextTick`, which appears to give the plugin's `_after` promise a chance to resolve prior to execution moving on to the next plugin.