### PR TITLE
test: change test case for avvio

### DIFF
--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -50,6 +50,32 @@ test('await after without server', async (t) => {
   t.pass('reachable')
 })
 
+test('await after with cb functions', async (t) => {
+  const app = boot()
+  let secondLoaded = false
+  let record = ''
+
+  app.use(async (app) => {
+    t.pass('plugin init')
+    record += 'plugin|'
+    app.use(async () => {
+      t.pass('plugin2 init')
+      record += 'plugin2|'
+      await sleep(1)
+      secondLoaded = true
+    })
+  })
+  await app.after(() => {
+    record += 'after|'
+  })
+  t.pass('reachable')
+  t.equal(secondLoaded, true)
+  record += 'ready'
+  await app.ready()
+  t.pass('reachable')
+  t.equal(record, 'plugin|plugin2|after|ready')
+})
+
 test('await after - nested plugins with future tick callbacks', async (t) => {
   const app = {}
   boot(app)

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -19,6 +19,7 @@ boot.express(app)
 t.plan(2)
 
 let loaded = false
+let server
 
 app.load(function (app, opts, done) {
   loaded = true
@@ -31,12 +32,12 @@ app.load(function (app, opts, done) {
 
 app.after((cb) => {
   t.ok(loaded, 'plugin loaded')
-  const server = app.listen(3000, cb)
+  server = app.listen(0, cb)
   t.teardown(server.close.bind(server))
 })
 
 app.ready(() => {
-  http.get('http://localhost:3000').on('response', function (res) {
+  http.get(`http://localhost:${server.address().port}`).on('response', function (res) {
     let data = ''
     res.on('data', function (chunk) {
       data += chunk


### PR DESCRIPTION
Just some changes for test cases while I run `npm run test` in my env.
for `express.test.js`, makes port random, `3000` is easy to be Occupied
for `awat-after.test.js`, add a case with `after` callback function, and use `record` param to record the execution order

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
