### PR TITLE
fix: delay plugin loading until next tick

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -249,9 +249,7 @@ Plugin.prototype.finish = function (err, cb) {
 // to run prior to executing the next plugin
 function loadPluginNextTick (toLoad, cb) {
   const parent = this
-  process.nextTick(() => {
-    loadPlugin.call(parent, toLoad, cb)
-  })
+  process.nextTick(loadPlugin.bind(parent), toLoad, cb)
 }
 
 // loads a plugin

--- a/plugin.js
+++ b/plugin.js
@@ -40,6 +40,13 @@ function promise () {
   return obj
 }
 
+function loadPluginNextTick (toLoad, cb) {
+  const parent = this
+  process.nextTick(() => {
+    loadPlugin.call(parent, toLoad, cb)
+  })
+}
+
 function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.started = false
   this.func = func
@@ -49,7 +56,7 @@ function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.timeout = timeout === undefined ? parent._timeout : timeout
   this.name = getName(func, optsOrFunc)
   this.isAfter = isAfter
-  this.q = fastq(parent, loadPlugin, 1)
+  this.q = fastq(parent, loadPluginNextTick, 1)
   this.q.pause()
   this._error = null
   this.loaded = false

--- a/plugin.js
+++ b/plugin.js
@@ -40,13 +40,6 @@ function promise () {
   return obj
 }
 
-function loadPluginNextTick (toLoad, cb) {
-  const parent = this
-  process.nextTick(() => {
-    loadPlugin.call(parent, toLoad, cb)
-  })
-}
-
 function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
   this.started = false
   this.func = func
@@ -250,6 +243,15 @@ Plugin.prototype.finish = function (err, cb) {
   // we start loading the dependents plugins only once
   // the current level is finished
   this.q.resume()
+}
+
+// delays plugin loading until the next tick to ensure any bound `_after` callbacks have a chance
+// to run prior to executing the next plugin
+function loadPluginNextTick (toLoad, cb) {
+  const parent = this
+  process.nextTick(() => {
+    loadPlugin.call(parent, toLoad, cb)
+  })
 }
 
 // loads a plugin

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -311,7 +311,7 @@ test('await after complex scenario', async (t) => {
 test('without autostart and sync/async plugin mix', async (t) => {
   const app = {}
   boot(app, { autostart: false })
-  t.plan(22)
+  t.plan(21)
 
   let firstLoaded = false
   let secondLoaded = false
@@ -324,9 +324,6 @@ test('without autostart and sync/async plugin mix', async (t) => {
   t.notOk(secondLoaded, 'second is not loaded')
   t.notOk(thirdLoaded, 'third is not loaded')
   t.notOk(fourthLoaded, 'fourth is not loaded')
-
-  const contents = await fs.readFile(path.join(__dirname, 'fixtures', 'dummy.txt'), 'utf-8')
-  t.equal(contents, 'hello, world!')
 
   app.use(second)
   await app.after()

--- a/test/fixtures/dummy.txt
+++ b/test/fixtures/dummy.txt
@@ -1,0 +1,1 @@
+hello, world!


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


## Description
This PR is a followup to #173.  That original PR attempted to fix the async plugin loading issue described in [fastify/3726](https://github.com/fastify/fastify/issues/3726) by delaying each plugin's `after` promise resolution until the next tick.  However, this resulted in a subtle but significant change where subsequent plugin registration functions were now being enqueued in `this.q` and executed on the same tick of the event loop as registration, a consequence of the registration function being the only item in `this.q`.  We observed a symptom of this change in the unrelated unit test linked below:

https://github.com/fastify/avvio/pull/173/files#r814200533

We didn't think the above was a major/breaking change in behavior, but that proved to be incorrect per this bug report:

https://github.com/fastify/fastify-cors/issues/189

This PR improves on the initial PR by delaying the entire loading of each plugin to the next tick rather than just the plugin's `after` promise resolution.  This change has been tested in @pvanagtmaal's [test repo]( https://github.com/pvanagtmaal/fastify-test) and produces the expected output for both the working and previously-broken test cases:

```
➜  fastify-test git:(main) ✗ node working.js
cors registered
└── /
    ├── /
    ├── * (OPTIONS)
    └── v
        ├── 1/user (GET)
        └── 2/user (GET)

➜  fastify-test git:(main) ✗ node broken.js
└── /
    ├── /
    ├── * (OPTIONS)
    └── v
        ├── 1/user (GET)
        └── 2/user (GET)
```

It also doesn't require any unexpected changes in [unrelated test cases like the previous PR](https://github.com/fastify/avvio/pull/173/files#r814200533).