### PR TITLE
ci: nodejs version update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 17]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
`Fastify` main branch has update nodejs version to `14,16,17`. I think it is necessary to keep versions the same with `Fastify`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
