### PR TITLE
chore: drop queue-mircotask

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "archy": "^1.0.0",
     "debug": "^4.0.0",
-    "fastq": "^1.6.1",
-    "queue-microtask": "^1.1.2"
+    "fastq": "^1.6.1"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const queueMicrotask = require('queue-microtask')
 const fastq = require('fastq')
 const EE = require('events').EventEmitter
 const inherits = require('util').inherits


### PR DESCRIPTION
Because of `Fastify` v4 has dropped node 10 & node 12, so it is useless to require queue-mircotask anymore. And this will cause a breaking change in node 10 or earlier.(queueMircotask is supported in node 11)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
