### PR TITLE
chore: change plugin.js to class statement

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,17 +1,17 @@
 'use strict'
 
 const fastq = require('fastq')
-const EE = require('events').EventEmitter
-const inherits = require('util').inherits
+const EventEmitter = require('events')
 const debug = require('debug')('avvio')
 const { AVV_ERR_READY_TIMEOUT } = require('./lib/errors')
 
 // this symbol is assigned by fastify-plugin
 const kPluginMeta = Symbol.for('plugin-meta')
+function noop () {}
 
 function getName (func, optsOrFunc) {
   // use explicit function metadata if set
-  if (func[kPluginMeta] && func[kPluginMeta].name) {
+  if (func[kPluginMeta]?.name) {
     return func[kPluginMeta].name
   }
 
@@ -39,209 +39,211 @@ function promise () {
   return obj
 }
 
-function Plugin (parent, func, optsOrFunc, isAfter, timeout) {
-  this.started = false
-  this.func = func
-  this.opts = optsOrFunc
-  this.onFinish = null
-  this.parent = parent
-  this.timeout = timeout === undefined ? parent._timeout : timeout
-  this.name = getName(func, optsOrFunc)
-  this.isAfter = isAfter
-  this.q = fastq(parent, loadPluginNextTick, 1)
-  this.q.pause()
-  this._error = null
-  this.loaded = false
-  this._promise = null
+class Plugin extends EventEmitter {
+  constructor (parent, func, optsOrFunc, isAfter, timeout) {
+    super()
 
-  // always start the queue in the next tick
-  // because we try to attach subsequent call to use()
-  // to the right plugin. we need to defer them,
-  // or they will end up at the top of _current
-}
+    this.started = false
+    this.func = func
+    this.opts = optsOrFunc
+    this.onFinish = null
+    this.parent = parent
+    this.timeout = timeout === undefined ? parent._timeout : timeout
+    this.name = getName(func, optsOrFunc)
+    this.isAfter = isAfter
+    this.q = fastq(parent, loadPluginNextTick, 1)
+    this.q.pause()
+    this._error = null
+    this.loaded = false
+    this._promise = null
 
-inherits(Plugin, EE)
-
-Plugin.prototype.exec = function (server, cb) {
-  const func = this.func
-  let completed = false
-  const name = this.name
-
-  if (this.parent._error && !this.isAfter) {
-    debug('skipping loading of plugin as parent errored and it is not an after', name)
-    process.nextTick(cb)
-    return
+    // always start the queue in the next tick
+    // because we try to attach subsequent call to use()
+    // to the right plugin. we need to defer them,
+    // or they will end up at the top of _current
   }
 
-  if (!this.isAfter) {
-    // Skip override for after
-    try {
-      this.server = this.parent.override(server, func, this.opts)
-    } catch (err) {
-      debug('override errored', name)
-      return cb(err)
-    }
-  } else {
-    this.server = server
-  }
+  exec (server, cb) {
+    const func = this.func
+    let completed = false
+    const name = this.name
 
-  this.opts = typeof this.opts === 'function' ? this.opts(this.server) : this.opts
-
-  debug('exec', name)
-
-  let timer
-
-  const done = (err) => {
-    if (completed) {
-      debug('loading complete', name)
+    if (this.parent._error && !this.isAfter) {
+      debug('skipping loading of plugin as parent errored and it is not an after', name)
+      process.nextTick(cb)
       return
     }
 
-    this._error = err
-
-    if (err) {
-      debug('exec errored', name)
+    if (!this.isAfter) {
+      // Skip override for after
+      try {
+        this.server = this.parent.override(server, func, this.opts)
+      } catch (err) {
+        debug('override errored', name)
+        return cb(err)
+      }
     } else {
-      debug('exec completed', name)
+      this.server = server
     }
 
-    completed = true
+    this.opts = typeof this.opts === 'function' ? this.opts(this.server) : this.opts
 
-    if (timer) {
-      clearTimeout(timer)
-    }
+    debug('exec', name)
 
-    cb(err)
-  }
+    let timer
 
-  if (this.timeout > 0) {
-    debug('setting up timeout', name, this.timeout)
-    timer = setTimeout(function () {
-      debug('timed out', name)
-      timer = null
-      const err = new AVV_ERR_READY_TIMEOUT(name)
-      err.fn = func
-      done(err)
-    }, this.timeout)
-  }
+    const done = (err) => {
+      if (completed) {
+        debug('loading complete', name)
+        return
+      }
 
-  this.started = true
-  this.emit('start', this.server ? this.server.name : null, this.name, Date.now())
-  const promise = func(this.server, this.opts, done)
-
-  if (promise && typeof promise.then === 'function') {
-    debug('exec: resolving promise', name)
-
-    promise.then(
-      () => process.nextTick(done),
-      (e) => process.nextTick(done, e))
-  }
-}
-
-Plugin.prototype.loadedSoFar = function () {
-  if (this.loaded) {
-    return Promise.resolve()
-  }
-
-  const setup = () => {
-    this.server.after((err, cb) => {
       this._error = err
-      this.q.pause()
 
       if (err) {
-        debug('rejecting promise', this.name, err)
-        this._promise.reject(err)
+        debug('exec errored', name)
       } else {
-        debug('resolving promise', this.name)
-        this._promise.resolve()
+        debug('exec completed', name)
       }
-      this._promise = null
 
-      process.nextTick(cb, err)
-    })
-    this.q.resume()
-  }
+      completed = true
 
-  let res
+      if (timer) {
+        clearTimeout(timer)
+      }
 
-  if (!this._promise) {
-    this._promise = promise()
-    res = this._promise.promise
-
-    if (!this.server) {
-      this.on('start', setup)
-    } else {
-      setup()
+      cb(err)
     }
-  } else {
-    res = Promise.resolve()
+
+    if (this.timeout > 0) {
+      debug('setting up timeout', name, this.timeout)
+      timer = setTimeout(function () {
+        debug('timed out', name)
+        timer = null
+        const err = new AVV_ERR_READY_TIMEOUT(name)
+        err.fn = func
+        done(err)
+      }, this.timeout)
+    }
+
+    this.started = true
+    this.emit('start', this.server?.name || null, this.name, Date.now())
+    const promise = func(this.server, this.opts, done)
+
+    if (promise && typeof promise.then === 'function') {
+      debug('exec: resolving promise', name)
+
+      promise.then(
+        () => process.nextTick(done),
+        (e) => process.nextTick(done, e))
+    }
   }
 
-  return res
-}
-
-Plugin.prototype.enqueue = function (obj, cb) {
-  debug('enqueue', this.name, obj.name)
-  this.emit('enqueue', this.server ? this.server.name : null, this.name, Date.now())
-  this.q.push(obj, cb)
-}
-
-Plugin.prototype.finish = function (err, cb) {
-  debug('finish', this.name, err)
-  const done = () => {
+  loadedSoFar () {
     if (this.loaded) {
+      return Promise.resolve()
+    }
+
+    const setup = () => {
+      this.server.after((err, cb) => {
+        this._error = err
+        this.q.pause()
+
+        if (err) {
+          debug('rejecting promise', this.name, err)
+          this._promise.reject(err)
+        } else {
+          debug('resolving promise', this.name)
+          this._promise.resolve()
+        }
+        this._promise = null
+
+        process.nextTick(cb, err)
+      })
+      this.q.resume()
+    }
+
+    let res
+
+    if (!this._promise) {
+      this._promise = promise()
+      res = this._promise.promise
+
+      if (!this.server) {
+        this.on('start', setup)
+      } else {
+        setup()
+      }
+    } else {
+      res = Promise.resolve()
+    }
+
+    return res
+  }
+
+  enqueue (obj, cb) {
+    debug('enqueue', this.name, obj.name)
+    this.emit('enqueue', this.server?.name || null, this.name, Date.now())
+    this.q.push(obj, cb)
+  }
+
+  finish (err, cb) {
+    debug('finish', this.name, err)
+    const done = () => {
+      if (this.loaded) {
+        return
+      }
+
+      debug('loaded', this.name)
+      this.emit('loaded', this.server?.name || null, this.name, Date.now())
+      this.loaded = true
+
+      cb(err)
+    }
+
+    if (err) {
+      if (this._promise) {
+        this._promise.reject(err)
+        this._promise = null
+      }
+      done()
       return
     }
 
-    debug('loaded', this.name)
-    this.emit('loaded', this.server ? this.server.name : null, this.name, Date.now())
-    this.loaded = true
+    const check = () => {
+      debug('check', this.name, this.q.length(), this.q.running(), this._promise)
+      if (this.q.length() === 0 && this.q.running() === 0) {
+        if (this._promise) {
+          const wrap = () => {
+            debug('wrap')
+            queueMicrotask(check)
+          }
+          this._promise.resolve()
+          this._promise.promise.then(wrap, wrap)
+          this._promise = null
+        } else {
+          done()
+        }
+      } else {
+        debug('delayed', this.name)
+        // finish when the queue of nested plugins to load is empty
+        this.q.drain = () => {
+          debug('drain', this.name)
+          this.q.drain = noop
 
-    cb(err)
-  }
-
-  if (err) {
-    if (this._promise) {
-      this._promise.reject(err)
-      this._promise = null
-    }
-    done()
-    return
-  }
-
-  const check = () => {
-    debug('check', this.name, this.q.length(), this.q.running(), this._promise)
-    if (this.q.length() === 0 && this.q.running() === 0) {
-      if (this._promise) {
-        const wrap = () => {
-          debug('wrap')
+          // we defer the check, as a safety net for things
+          // that might be scheduled in the loading callback
           queueMicrotask(check)
         }
-        this._promise.resolve()
-        this._promise.promise.then(wrap, wrap)
-        this._promise = null
-      } else {
-        done()
-      }
-    } else {
-      debug('delayed', this.name)
-      // finish when the queue of nested plugins to load is empty
-      this.q.drain = () => {
-        debug('drain', this.name)
-        this.q.drain = noop
-
-        // we defer the check, as a safety net for things
-        // that might be scheduled in the loading callback
-        queueMicrotask(check)
       }
     }
+
+    queueMicrotask(check)
+
+    // we start loading the dependents plugins only once
+    // the current level is finished
+    this.q.resume()
   }
-
-  queueMicrotask(check)
-
-  // we start loading the dependents plugins only once
-  // the current level is finished
-  this.q.resume()
 }
 
 // delays plugin loading until the next tick to ensure any bound `_after` callbacks have a chance
@@ -269,15 +271,13 @@ function loadPlugin (toLoad, cb) {
   // place the plugin at the top of _current
   this._current.unshift(toLoad)
 
-  toLoad.exec((last && last.server) || this._server, (err) => {
+  toLoad.exec(last?.server || this._server, (err) => {
     toLoad.finish(err, (err) => {
       this._current.shift()
       cb(err)
     })
   })
 }
-
-function noop () {}
 
 module.exports = Plugin
 module.exports.loadPlugin = loadPlugin


### PR DESCRIPTION
change `plugin.js` to class statement

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
