### PR TITLE
Make sure we always start in a microtick

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -334,7 +334,7 @@ Boot.prototype.ready = function (func) {
       throw new AVV_ERR_CALLBACK_NOT_FN('ready', typeof func)
     }
     this._readyQ.push(func)
-    this.start()
+    queueMicrotask(this.start.bind(this))
     return
   }
 

--- a/test/await-use.test.js
+++ b/test/await-use.test.js
@@ -270,3 +270,25 @@ test('await use - mix of same and future tick callbacks', async (t) => {
   record += 'ready'
   t.equal(record, 'plugin0|plugin1|plugin2|ready')
 })
+
+test('await use - fork the promise chain', { only: true }, (t) => {
+  t.plan(3)
+  const app = {}
+  boot(app, { autostart: false })
+
+  async function setup () {
+    let set = false
+    await app.use(async function plugin0 () {
+      t.pass('plugin0 init')
+      await sleep(500)
+      set = true
+    })
+    t.equal(set, true)
+  }
+  setup()
+
+  app.ready((err, done) => {
+    t.error(err)
+    done()
+  })
+})

--- a/test/chainable.test.js
+++ b/test/chainable.test.js
@@ -63,7 +63,7 @@ test('chainable automatically binded', (t) => {
     expose[key] = 'muahah'
 
     boot(app, {
-      expose: expose
+      expose
     })
 
     t.end()


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>
Fixes: https://github.com/fastify/fastify/issues/4125

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
