### PR TITLE
Fixed error in queue when timeout is 0

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -426,10 +426,15 @@ function callWithCbOrNextTick (func, cb) {
     }
   } else {
     if (this._timeout === 0) {
+      const wrapCb = (err) => {
+        this._error = err
+        cb(this._error)
+      }
+
       if (func.length === 2) {
-        func(err, cb)
+        func(err, wrapCb)
       } else {
-        func(err, context, cb)
+        func(err, context, wrapCb)
       }
     } else {
       timeoutCall.call(this, func, err, context, cb)

--- a/test/async-await.test.js
+++ b/test/async-await.test.js
@@ -305,3 +305,17 @@ test('skip override with promise', (t) => {
     return fn
   }
 })
+
+test('ready queue error', async (t) => {
+  const app = boot()
+  app.use(first)
+
+  async function first (s, opts) {}
+
+  app.ready(function (_, worker, done) {
+    const error = new Error('kaboom')
+    done(error)
+  })
+
+  await t.rejects(app.ready(), { message: 'kaboom' })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixed crash when error is thrown in ready queue when timeout is 0

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
