### PR TITLE
use @fastify/error

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,46 +1,8 @@
 'use strict'
-// Code inherited from fastify-error
-const { inherits, format } = require('util')
 
-function createError (code, message, Base = Error) {
-  if (!code) throw new Error('Avvio error code must not be empty')
-  if (!message) throw new Error('Avvio base error message must not be empty')
-
-  function AvvioError (a, b, c) {
-    if (!new.target) {
-      return new AvvioError(a, b, c)
-    }
-
-    Error.captureStackTrace(this, AvvioError)
-
-    this.code = code
-    this.message = message
-    this.name = 'AvvioError'
-
-    // more performant than spread (...) operator
-    if (a && b && c) {
-      this.message = format(message, a, b, c)
-    } else if (a && b) {
-      this.message = format(message, a, b)
-    } else if (a) {
-      this.message = format(message, a)
-    } else {
-      this.message = message
-    }
-  }
-
-  AvvioError.prototype[Symbol.toStringTag] = 'Error'
-  AvvioError.prototype.toString = function () {
-    return `${this.name} [${this.code}]: ${this.message}`
-  }
-
-  inherits(AvvioError, Base)
-
-  return AvvioError
-}
+const { createError } = require('@fastify/error')
 
 module.exports = {
-  createError,
   AVV_ERR_EXPOSE_ALREADY_DEFINED: createError(
     'AVV_ERR_EXPOSE_ALREADY_DEFINED',
     "'%s' () is already defined, specify an expose option"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
+    "@fastify/error": "^3.3.0",
     "fastq": "^1.6.1"
   }
 }

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -2,101 +2,6 @@
 
 const { test } = require('tap')
 const errors = require('../lib/errors')
-const createError = errors.createError
-
-const expectedErrorName = 'AvvioError'
-
-test('Create error with zero parameter', t => {
-  t.plan(5)
-  const NewError = createError('CODE', 'Not available')
-  const err = new NewError()
-  t.ok(err instanceof Error)
-  t.ok(err.stack)
-  t.equal(err.name, expectedErrorName)
-  t.equal(err.message, 'Not available')
-  t.equal(err.code, 'CODE')
-})
-
-test('Create error with 1 parameter', t => {
-  t.plan(5)
-  const NewError = createError('CODE', 'hey %s')
-  const err = new NewError('alice')
-  t.ok(err instanceof Error)
-  t.ok(err.stack)
-  t.equal(err.name, expectedErrorName)
-  t.equal(err.message, 'hey alice')
-  t.equal(err.code, 'CODE')
-})
-
-test('Create error with 2 parameters', t => {
-  t.plan(5)
-  const NewError = createError('CODE', 'hey %s, I like your %s')
-  const err = new NewError('alice', 'attitude')
-  t.ok(err instanceof Error)
-  t.ok(err.stack)
-  t.equal(err.name, expectedErrorName)
-  t.equal(err.message, 'hey alice, I like your attitude')
-  t.equal(err.code, 'CODE')
-})
-
-test('Create error with 3 parameters', t => {
-  t.plan(5)
-  const NewError = createError('CODE', 'hey %s, I like your %s %s')
-  const err = new NewError('alice', 'attitude', 'see you')
-  t.ok(err instanceof Error)
-  t.ok(err.stack)
-  t.equal(err.name, expectedErrorName)
-  t.equal(err.message, 'hey alice, I like your attitude see you')
-  t.equal(err.code, 'CODE')
-})
-
-test('Should throw when error code has no Avvio code', t => {
-  t.plan(1)
-  try {
-    createError()
-  } catch (err) {
-    t.equal(err.message, 'Avvio error code must not be empty')
-  }
-})
-
-test('Should throw when error code has no message', t => {
-  t.plan(1)
-  try {
-    createError('code')
-  } catch (err) {
-    t.equal(err.message, 'Avvio base error message must not be empty')
-  }
-})
-
-test('Create error with different base', t => {
-  t.plan(6)
-  const NewError = createError('CODE', 'hey %s', TypeError)
-  const err = new NewError('dude')
-  t.ok(err instanceof Error)
-  t.ok(err instanceof TypeError)
-  t.ok(err.stack)
-  t.equal(err.name, expectedErrorName)
-  t.equal(err.message, 'hey dude')
-  t.equal(err.code, 'CODE')
-})
-
-test('AvvioError.toString returns code', t => {
-  t.plan(1)
-  const NewError = createError('CODE', 'foo')
-  const err = new NewError()
-  t.equal(err.toString(), 'AvvioError [CODE]: foo')
-})
-
-test('Create the error without the new keyword', t => {
-  t.plan(5)
-  const NewError = createError('CODE', 'Not available')
-  const err = NewError()
-  t.ok(err instanceof Error)
-  t.ok(err.stack)
-  t.equal(err.name, expectedErrorName)
-  t.equal(err.message, 'Not available')
-  t.equal(err.code, 'CODE')
-})
 
 test('Correct codes of AvvioErrors', t => {
   const testcases = [
@@ -110,7 +15,7 @@ test('Correct codes of AvvioErrors', t => {
 
   t.plan(testcases.length + 1)
   // errors.js exposes errors and the createError fn
-  t.equal(testcases.length + 1, Object.keys(errors).length)
+  t.equal(testcases.length, Object.keys(errors).length)
 
   for (const testcase of testcases) {
     const error = new errors[testcase]()


### PR DESCRIPTION
alternative to #197 

@mcollina asked if we can use @fastify/error directly. This PR uses @fastify/error instead of AVVIO own implementation. Only difference is, that the name of the Errors will be FastifyError instead of AvvioError.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
