### PR TITLE
use named export for timeTree, use null as initialization value for TimeTreeNode.stop

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -10,7 +10,7 @@ const {
   AVV_ERR_ROOT_PLG_BOOTED,
   AVV_ERR_READY_TIMEOUT
 } = require('./lib/errors')
-const TimeTree = require('./lib/time-tree')
+const { TimeTree } = require('./lib/time-tree')
 const Plugin = require('./plugin')
 const { debug } = require('./lib/debug')
 const kAvvio = Symbol('kAvvio')

--- a/lib/time-tree.js
+++ b/lib/time-tree.js
@@ -98,7 +98,7 @@ class TimeTree {
         label,
         nodes: [],
         start,
-        stop: undefined,
+        stop: null,
         diff: -1
       }
       this[kTrackNode](this.root)
@@ -116,7 +116,7 @@ class TimeTree {
       label,
       nodes: [],
       start,
-      stop: undefined,
+      stop: null,
       diff: -1
     }
     parentNode.nodes.push(childNode)
@@ -186,4 +186,6 @@ function prettyPrintTimeTree (obj, prefix = '') {
   return result
 }
 
-module.exports = TimeTree
+module.exports = {
+  TimeTree
+}

--- a/test/lib/time-tree.test.js
+++ b/test/lib/time-tree.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
-const TimeTree = require('../../lib/time-tree')
+const { TimeTree } = require('../../lib/time-tree')
 
 test('TimeTree is constructed with a root attribute, set to null', t => {
   t.plan(1)
@@ -60,7 +60,7 @@ test('TimeTree#start is adding a node with correct shape, root-node', t => {
   t.ok('start' in rootNode)
   t.ok(Number.isInteger(rootNode.start))
   t.ok('stop' in rootNode)
-  t.type(rootNode.stop, 'undefined')
+  t.type(rootNode.stop, 'null')
   t.ok('diff' in rootNode)
   t.type(rootNode.diff, 'number')
 })
@@ -90,7 +90,7 @@ test('TimeTree#start is adding a node with correct shape, child-node', t => {
   t.ok('start' in childNode)
   t.ok(Number.isInteger(childNode.start))
   t.ok('stop' in childNode)
-  t.type(childNode.stop, 'undefined')
+  t.type(childNode.stop, 'null')
   t.ok('diff' in childNode)
   t.type(childNode.diff, 'number')
 })
@@ -226,7 +226,7 @@ test('TimeTree#stop sets stop value of node', t => {
 
   const tree = new TimeTree()
   tree.start(null, 'root')
-  t.type(tree.root.stop, 'undefined')
+  t.type(tree.root.stop, 'null')
 
   tree.stop('root')
   t.type(tree.root.stop, 'number')
@@ -238,7 +238,7 @@ test('TimeTree#stop parameter stop is used as stop value of node', t => {
 
   const tree = new TimeTree()
   tree.start(null, 'root')
-  t.type(tree.root.stop, 'undefined')
+  t.type(tree.root.stop, 'null')
 
   tree.stop('root', 1337)
   t.type(tree.root.stop, 'number')
@@ -263,10 +263,10 @@ test('TimeTree#stop does nothing when node is not found', t => {
 
   const tree = new TimeTree()
   tree.start(null, 'root')
-  t.type(tree.root.stop, 'undefined')
+  t.type(tree.root.stop, 'null')
 
   tree.stop('invalid')
-  t.type(tree.root.stop, 'undefined')
+  t.type(tree.root.stop, 'null')
 })
 
 test('TimeTree untracks node ids /1', t => {


### PR DESCRIPTION
Based on #218 I assume that we should use null as initializiation value for stop. 
Also making named export for TimeTree to keep the style we use in the new files ;)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
