### PR TITLE
improve jsdoc and parameter names

### DIFF
--- a/lib/create-promise.js
+++ b/lib/create-promise.js
@@ -1,10 +1,22 @@
 'use strict'
 
 /**
+ * @callback PromiseResolve
+ * @param {any|PromiseLike<any>} value
+ * @returns {void}
+ */
+
+/**
+ * @callback PromiseReject
+ * @param {any} reason
+ * @returns {void}
+ */
+
+/**
  * @typedef PromiseObject
  * @property {Promise} promise
- * @property {PromiseConstructor["resolve"]} resolve
- * @property {PromiseConstructor["reject"]} reject
+ * @property {PromiseResolve} resolve
+ * @property {PromiseReject} reject
  */
 
 /**
@@ -12,8 +24,8 @@
  */
 function createPromise () {
   /**
-     * @type {PromiseObject}
-     */
+   * @type {PromiseObject}
+   */
   const obj = {
     resolve: null,
     reject: null,

--- a/lib/is-bundled-or-typescript-plugin.js
+++ b/lib/is-bundled-or-typescript-plugin.js
@@ -7,12 +7,15 @@
  */
 
 /**
- * @param {unknown} plugin
+ * @param {any} maybeBundledOrTypescriptPlugin
  * @returns {plugin is BundledOrTypescriptPlugin}
  */
-
-function isBundledOrTypescriptPlugin (plugin) {
-  return plugin !== null && typeof plugin === 'object' && typeof plugin.default === 'function'
+function isBundledOrTypescriptPlugin (maybeBundledOrTypescriptPlugin) {
+  return (
+    maybeBundledOrTypescriptPlugin !== null &&
+    typeof maybeBundledOrTypescriptPlugin === 'object' &&
+    typeof maybeBundledOrTypescriptPlugin.default === 'function'
+  )
 }
 
 module.exports = {

--- a/lib/validate-plugin.js
+++ b/lib/validate-plugin.js
@@ -3,19 +3,20 @@
 const { AVV_ERR_PLUGIN_NOT_VALID } = require('./errors')
 
 /**
- * @param {unknown} plugin
+ * @param {any} maybePlugin
  * @throws {AVV_ERR_PLUGIN_NOT_VALID}
- * @returns {Function}
+ *
+ * @returns {asserts plugin is Function|PromiseLike}
  */
-function validatePlugin (plugin) {
+function validatePlugin (maybePlugin) {
   // validate if plugin is a function or Promise
-  if (!(plugin && (typeof plugin === 'function' || typeof plugin.then === 'function'))) {
-    if (Array.isArray(plugin)) {
+  if (!(maybePlugin && (typeof maybePlugin === 'function' || typeof maybePlugin.then === 'function'))) {
+    if (Array.isArray(maybePlugin)) {
       throw new AVV_ERR_PLUGIN_NOT_VALID('array')
-    } else if (plugin === null) {
+    } else if (maybePlugin === null) {
       throw new AVV_ERR_PLUGIN_NOT_VALID('null')
     } else {
-      throw new AVV_ERR_PLUGIN_NOT_VALID(typeof plugin)
+      throw new AVV_ERR_PLUGIN_NOT_VALID(typeof maybePlugin)
     }
   }
 }


### PR DESCRIPTION
While working with jsdoc checking with typescript, I realized the jsdoc typings have issues. So I fixed them here.
Also renamed the parameter names to maybeX in the typeguards
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
