### PR TITLE
fix: calling avvio with new

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -101,14 +101,12 @@ function Boot (server, opts, done) {
 
   opts = opts || {}
 
-  if (!(this instanceof Boot)) {
-    const instance = new Boot(server, opts, done)
+  if (!new.target) {
+    return new Boot(server, opts, done)
+  }
 
-    if (server) {
-      wrap(server, opts, instance)
-    }
-
-    return instance
+  if (server) {
+    wrap(server, opts, this)
   }
 
   if (opts.autostart !== false) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -97,11 +97,40 @@ test('boot a plugin with a custom server', (t) => {
   })
 })
 
-test('custom instance should inherits avvio methods', (t) => {
+test('custom instance should inherits avvio methods /1', (t) => {
   t.plan(6)
 
   const server = {}
   const app = boot(server, {})
+
+  server.use(function (s, opts, done) {
+    t.equal(s, server, 'the first argument is the server')
+    t.same(opts, {}, 'no options')
+    done()
+  }).after(() => {
+    t.ok('after called')
+  })
+
+  server.onClose(() => {
+    t.ok('onClose called')
+  })
+
+  server.ready(() => {
+    t.ok('ready called')
+  })
+
+  app.on('start', () => {
+    server.close(() => {
+      t.pass('booted')
+    })
+  })
+})
+
+test('custom instance should inherits avvio methods /2', (t) => {
+  t.plan(6)
+
+  const server = {}
+  const app = new boot(server, {}) // eslint-disable-line new-cap
 
   server.use(function (s, opts, done) {
     t.equal(s, server, 'the first argument is the server')


### PR DESCRIPTION
This PR fixes an issue, where calling avvio with new would result in a broken result, as enriching the instance with the avvio attributes would only happen if we didnt call it with new. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
