### PR TITLE
chore: remove _isOnCloseHandlerKey

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -123,7 +123,7 @@ function Boot (server, opts, done) {
   this._current = []
 
   this._error = null
-  this._isOnCloseHandlerKey = kIsOnCloseHandler
+
   this._lastUsed = null
 
   this.setMaxListeners(0)
@@ -289,7 +289,7 @@ Boot.prototype.onClose = function (func) {
     throw new Error('not a function')
   }
 
-  func[this._isOnCloseHandlerKey] = true
+  func[kIsOnCloseHandler] = true
   this._closeQ.unshift(func, callback.bind(this))
 
   function callback (err) {
@@ -537,7 +537,7 @@ function timeoutCall (func, rootErr, context, cb) {
 
 function closeWithCbOrNextTick (func, cb) {
   const context = this._server
-  const isOnCloseHandler = func[this._isOnCloseHandlerKey]
+  const isOnCloseHandler = func[kIsOnCloseHandler]
   if (func.length === 0 || func.length === 1) {
     let promise
     if (isOnCloseHandler) {


### PR DESCRIPTION
We dont need this attribute, when we can refer to the symbol directly

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
