### PR TITLE
chore: add _trackPluginLoading method and fix root name

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,11 +616,11 @@ avvio.on('preReady', () => {
 The output is like this:
 ```json
 {
-  "label": "bound root",
+  "label": "root",
   "start": 1550245184665,
   "nodes": [
     {
-      "parent": "bound root",
+      "parent": "root",
       "start": 1550245184665,
       "label": "first",
       "nodes": [
@@ -637,7 +637,7 @@ The output is like this:
       "diff": 44
     },
     {
-      "parent": "bound root",
+      "parent": "root",
       "start": 1550245184709,
       "label": "third",
       "nodes": [],

--- a/boot.js
+++ b/boot.js
@@ -109,9 +109,7 @@ function Boot (server, opts, done) {
     wrap(server, opts, this)
   }
 
-  if (opts.autostart !== false) {
-    opts.autostart = true
-  }
+  opts.autostart = opts.autostart !== false
 
   server = server || this
 
@@ -153,21 +151,22 @@ function Boot (server, opts, done) {
   }
 
   this._doStart = null
-  this._root = new Plugin(fastq(this, this._loadPluginNextTick, 1), root.bind(this), opts, false, 0)
-  this._root.once('start', (serverName, funcName, time) => {
-    const nodeId = this.pluginTree.start(null, funcName, time)
-    this._root.once('loaded', (serverName, funcName, time) => {
-      this.pluginTree.stop(nodeId, time)
-    })
-  })
+
+  const instance = this
+  this._root = new Plugin(fastq(this, this._loadPluginNextTick, 1), function root (server, opts, done) {
+    instance._doStart = done
+    opts.autostart && instance.start()
+  }, opts, false, 0)
+
+  this._trackPluginLoading(this._root)
 
   this._loadPlugin(this._root, (err) => {
     debug('root plugin ready')
     try {
       this.emit('preReady')
       this._root = null
-    } catch (prereadyError) {
-      err = err || this._error || prereadyError
+    } catch (preReadyError) {
+      err = err || this._error || preReadyError
     }
 
     if (err) {
@@ -180,13 +179,6 @@ function Boot (server, opts, done) {
     }
     this._readyQ.resume()
   })
-}
-
-function root (s, opts, done) {
-  this._doStart = done
-  if (opts.autostart) {
-    this.start()
-  }
 }
 
 inherits(Boot, EE)
@@ -231,11 +223,11 @@ Boot.prototype._loadRegistered = function () {
 
 Object.defineProperty(Boot.prototype, 'then', { get: thenify })
 
-Boot.prototype._addPlugin = function (plugin, opts, isAfter) {
-  if (isBundledOrTypescriptPlugin(plugin)) {
-    plugin = plugin.default
+Boot.prototype._addPlugin = function (pluginFn, opts, isAfter) {
+  if (isBundledOrTypescriptPlugin(pluginFn)) {
+    pluginFn = pluginFn.default
   }
-  validatePlugin(plugin)
+  validatePlugin(pluginFn)
   opts = opts || {}
 
   if (this.booted) {
@@ -245,26 +237,21 @@ Boot.prototype._addPlugin = function (plugin, opts, isAfter) {
   // we always add plugins to load at the current element
   const current = this._current[0]
 
-  const obj = new Plugin(fastq(this, this._loadPluginNextTick, 1), plugin, opts, isAfter, this._timeout)
-  obj.once('start', (serverName, funcName, time) => {
-    const nodeId = this.pluginTree.start(current.name, funcName, time)
-    obj.once('loaded', (serverName, funcName, time) => {
-      this.pluginTree.stop(nodeId, time)
-    })
-  })
+  const plugin = new Plugin(fastq(this, this._loadPluginNextTick, 1), pluginFn, opts, isAfter, this._timeout)
+  this._trackPluginLoading(plugin)
 
   if (current.loaded) {
-    throw new Error(obj.name, current.name)
+    throw new Error(plugin.name, current.name)
   }
 
   // we add the plugin to be loaded at the end of the current queue
-  current.enqueue(obj, (err) => {
+  current.enqueue(plugin, (err) => {
     if (err) {
       this._error = err
     }
   })
 
-  return obj
+  return plugin
 }
 
 Boot.prototype.after = function (func) {
@@ -357,6 +344,16 @@ Boot.prototype.ready = function (func) {
       }
       process.nextTick(done)
     }
+  })
+}
+
+Boot.prototype._trackPluginLoading = function (plugin) {
+  const parentName = this._current[0]?.name || null
+  plugin.once('start', (serverName, funcName, time) => {
+    const nodeId = this.pluginTree.start(parentName || null, funcName, time)
+    plugin.once('loaded', (serverName, funcName, time) => {
+      this.pluginTree.stop(nodeId, time)
+    })
   })
 }
 

--- a/boot.js
+++ b/boot.js
@@ -347,6 +347,10 @@ Boot.prototype.ready = function (func) {
   })
 }
 
+/**
+ * @param {Plugin} plugin
+ * @returns {void}
+ */
 Boot.prototype._trackPluginLoading = function (plugin) {
   const parentName = this._current[0]?.name || null
   plugin.once('start', (serverName, funcName, time) => {

--- a/boot.js
+++ b/boot.js
@@ -173,7 +173,7 @@ Boot.prototype._addPlugin = function (pluginFn, opts, isAfter) {
   // we always add plugins to load at the current element
   const current = this._current[0]
 
-  const plugin = new Plugin(fastq(this, this._loadPluginNextTick, 1), pluginFn, opts, isAfter, this._timeout)
+  const plugin = new Plugin(fastq(this, this._loadPluginNextTick, 1), pluginFn, opts, isAfter, this._opts.timeout)
   this._trackPluginLoading(plugin)
 
   if (current.loaded) {

--- a/test/gh-issues/bug-205.test.js
+++ b/test/gh-issues/bug-205.test.js
@@ -9,7 +9,7 @@ test('should print the time tree', (t) => {
 
   app.use(function first (instance, opts, cb) {
     const out = instance.prettyPrint().split('\n')
-    t.equal(out[0], 'bound root -1 ms')
+    t.equal(out[0], 'root -1 ms')
     t.equal(out[1], '└── first -1 ms')
     cb()
   })

--- a/test/plugin-name.test.js
+++ b/test/plugin-name.test.js
@@ -14,7 +14,7 @@ test('plugins get a name from the plugin metadata if it is set', async (t) => {
   await app.ready()
 
   t.match(app.toJSON(), {
-    label: 'bound root',
+    label: 'root',
     nodes: [
       { label: 'a-test-plugin' }
     ]
@@ -30,7 +30,7 @@ test('plugins get a name from the options if theres no metadata', async (t) => {
   await app.ready()
 
   t.match(app.toJSON(), {
-    label: 'bound root',
+    label: 'root',
     nodes: [
       { label: 'test registration options name' }
     ]
@@ -46,7 +46,7 @@ test('plugins get a name from the function name if theres no name in the options
   await app.ready()
 
   t.match(app.toJSON(), {
-    label: 'bound root',
+    label: 'root',
     nodes: [
       { label: 'testPlugin' }
     ]
@@ -61,7 +61,7 @@ test('plugins get a name from the function source if theres no other option', as
   await app.ready()
 
   t.match(app.toJSON(), {
-    label: 'bound root',
+    label: 'root',
     nodes: [
       { label: '(app, opts, next) => next()' }
     ]

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -15,7 +15,7 @@ test('pretty print', t => {
     .use(third).after(after)
     .use(duplicate, { count: 1 })
 
-  const linesExpected = [/^bound root \d+ ms$/,
+  const linesExpected = [/^root \d+ ms$/,
     /^├── first \d+ ms$/,
     /^├─┬ duplicate \d+ ms$/,
     /^│ └─┬ duplicate \d+ ms$/,

--- a/test/to-json.test.js
+++ b/test/to-json.test.js
@@ -14,7 +14,7 @@ test('to json', (t) => {
 
   const outJson = {
     id: 'root',
-    label: 'bound root',
+    label: 'root',
     start: /\d+/,
     nodes: []
   }
@@ -69,12 +69,12 @@ test('to json multi-level hierarchy', (t) => {
 
   const outJson = {
     id: 'root',
-    label: 'bound root',
+    label: 'root',
     start: /\d+/,
     nodes: [
       {
         id: /.+/,
-        parent: 'bound root',
+        parent: 'root',
         start: /\d+/,
         label: 'first',
         nodes: [


### PR DESCRIPTION
Simplify the code, add a _trackPluginLoading and also fix the root name. It will now show root and not "bound root". Which is nicer imho.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
