### PR TITLE
chore: move wrap to be method _expose()

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -208,7 +208,7 @@ Boot.prototype._expose = function _expose () {
     after: afterKey = 'after',
     ready: readyKey = 'ready',
     onClose: onCloseKey = 'onClose',
-    close: closeKey = 'close',
+    close: closeKey = 'close'
   } = this._opts.expose
 
   if (server[useKey]) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -5,7 +5,11 @@ const { createError } = require('@fastify/error')
 module.exports = {
   AVV_ERR_EXPOSE_ALREADY_DEFINED: createError(
     'AVV_ERR_EXPOSE_ALREADY_DEFINED',
-    "'%s' () is already defined, specify an expose option"
+    "'%s' is already defined, specify an expose option for '%s'"
+  ),
+  AVV_ERR_ATTRIBUTE_ALREADY_DEFINED: createError(
+    'AVV_ERR_ATTRIBUTE_ALREADY_DEFINED',
+    "'%s' is already defined"
   ),
   AVV_ERR_CALLBACK_NOT_FN: createError(
     'AVV_ERR_CALLBACK_NOT_FN',

--- a/test/chainable.test.js
+++ b/test/chainable.test.js
@@ -40,36 +40,6 @@ test('chainable automatically binded', (t) => {
   t.equal(readyResult, undefined)
 })
 
-;['use', 'after', 'ready'].forEach((key) => {
-  test('throws if ' + key + ' is already there', (t) => {
-    t.plan(1)
-
-    const app = {}
-    app[key] = () => {}
-
-    try {
-      boot(app)
-      t.fail('error must happen')
-    } catch (err) {
-      t.equal(err.message, `'${key}' () is already defined, specify an expose option`)
-    }
-  })
-
-  test('support expose for ' + key, (t) => {
-    const app = {}
-    app[key] = () => {}
-
-    const expose = {}
-    expose[key] = 'muahah'
-
-    boot(app, {
-      expose
-    })
-
-    t.end()
-  })
-})
-
 test('chainable standalone with server', (t) => {
   t.plan(6)
 

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -6,6 +6,7 @@ const errors = require('../lib/errors')
 test('Correct codes of AvvioErrors', t => {
   const testcases = [
     'AVV_ERR_EXPOSE_ALREADY_DEFINED',
+    'AVV_ERR_ATTRIBUTE_ALREADY_DEFINED',
     'AVV_ERR_CALLBACK_NOT_FN',
     'AVV_ERR_PLUGIN_NOT_VALID',
     'AVV_ERR_ROOT_PLG_BOOTED',

--- a/test/expose.test.js
+++ b/test/expose.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const { test } = require('tap')
+const boot = require('..')
+const { AVV_ERR_EXPOSE_ALREADY_DEFINED, AVV_ERR_ATTRIBUTE_ALREADY_DEFINED } = require('../lib/errors')
+const { kAvvio } = require('../lib/symbols')
+
+for (const key of ['use', 'after', 'ready', 'onClose', 'close']) {
+  test('throws if ' + key + ' is by default already there', (t) => {
+    t.plan(1)
+
+    const app = {}
+    app[key] = () => { }
+
+    t.throws(() => boot(app), new AVV_ERR_EXPOSE_ALREADY_DEFINED(key, key))
+  })
+
+  test('throws if ' + key + ' is already there', (t) => {
+    t.plan(1)
+
+    const app = {}
+    app['cust' + key] = () => { }
+
+    t.throws(() => boot(app, { expose: { [key]: 'cust' + key } }), new AVV_ERR_EXPOSE_ALREADY_DEFINED('cust' + key, key))
+  })
+
+  test('support expose for ' + key, (t) => {
+    const app = {}
+    app[key] = () => { }
+
+    const expose = {}
+    expose[key] = 'muahah'
+
+    boot(app, {
+      expose
+    })
+
+    t.end()
+  })
+}
+
+test('set the kAvvio to true on the server', (t) => {
+  t.plan(1)
+
+  const server = {}
+  boot(server)
+
+  t.ok(server[kAvvio])
+})
+
+test('.then()', t => {
+  t.plan(3)
+
+  t.test('.then() can not be overwritten', (t) => {
+    t.plan(1)
+
+    const server = {
+      then: () => {}
+    }
+    t.throws(() => boot(server), AVV_ERR_ATTRIBUTE_ALREADY_DEFINED('then'))
+  })
+
+  t.test('.then() is a function', (t) => {
+    t.plan(1)
+
+    const server = {}
+    boot(server)
+
+    t.type(server.then, 'function')
+  })
+
+  t.test('.then() can not be overwritten', (t) => {
+    t.plan(1)
+
+    const server = {}
+    boot(server)
+
+    t.throws(() => { server.then = 'invalid' }, TypeError('Cannot set property then of #<Object> which has only a getter'))
+  })
+})


### PR DESCRIPTION
Make wrap() function a method `_expose()`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
