### PR TITLE
fix: throw AVV_ERR_CALLBACK_NOT_FN in onClose instead of generic Error

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -281,7 +281,7 @@ Boot.prototype.onClose = function (func) {
   // because they share the same queue but must be called with different signatures
 
   if (typeof func !== 'function') {
-    throw new Error('not a function')
+    throw new AVV_ERR_CALLBACK_NOT_FN('onClose', typeof func)
   }
 
   func[this._isOnCloseHandlerKey] = true

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -61,10 +61,23 @@ test('boot an app with a promisified plugin', (t) => {
   })
 })
 
-test('boot an app with a plugin and a callback', (t) => {
+test('boot an app with a plugin and a callback /1', (t) => {
   t.plan(2)
 
   const app = boot(() => {
+    t.pass('booted')
+  })
+
+  app.use(function (server, opts, done) {
+    t.pass('plugin loaded')
+    done()
+  })
+})
+
+test('boot an app with a plugin and a callback /2', (t) => {
+  t.plan(2)
+
+  const app = boot({}, () => {
     t.pass('booted')
   })
 

--- a/test/close.test.js
+++ b/test/close.test.js
@@ -2,6 +2,7 @@
 
 const { test } = require('tap')
 const boot = require('..')
+const { AVV_ERR_CALLBACK_NOT_FN } = require('../lib/errors')
 
 test('boot an app with a plugin', (t) => {
   t.plan(4)
@@ -494,7 +495,7 @@ test('onClose callback must be a function', (t) => {
   const app = boot()
 
   app.use(function (server, opts, done) {
-    t.throws(() => app.onClose({}), { message: 'not a function' })
+    t.throws(() => app.onClose({}), new AVV_ERR_CALLBACK_NOT_FN('onClose', 'object'))
     done()
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
