### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ It allows the creation of an inheritance chain for the server instances.
 The first parameter is the server instance and the second is the plugin function while the third is the options object that you give to use.
 
 ```js
-const assert = require('assert')
+const assert = require('node:assert')
 const server = { count: 0 }
 const app = require('avvio')(server)
 

--- a/boot.js
+++ b/boot.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const fastq = require('fastq')
-const EE = require('events').EventEmitter
-const inherits = require('util').inherits
+const EE = require('node:events').EventEmitter
+const inherits = require('node:util').inherits
 const {
   AVV_ERR_EXPOSE_ALREADY_DEFINED,
   AVV_ERR_CALLBACK_NOT_FN,

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { debuglog } = require('util')
+const { debuglog } = require('node:util')
 
 /**
  * @callback DebugLogger

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { EventEmitter } = require('events')
-const { inherits } = require('util')
+const { EventEmitter } = require('node:events')
+const { inherits } = require('node:util')
 const { debug } = require('./debug')
 const { createPromise } = require('./create-promise')
 const { AVV_ERR_PLUGIN_EXEC_TIMEOUT } = require('./errors')

--- a/test/await-after.test.js
+++ b/test/await-after.test.js
@@ -2,10 +2,10 @@
 
 const { test } = require('tap')
 const boot = require('..')
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const sleep = promisify(setTimeout)
-const fs = require('fs').promises
-const path = require('path')
+const fs = require('node:fs').promises
+const path = require('node:path')
 
 test('await after - nested plugins with same tick callbacks', async (t) => {
   const app = {}

--- a/test/await-use.test.js
+++ b/test/await-use.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
-const { promisify } = require('util')
+const { promisify } = require('node:util')
 const sleep = promisify(setTimeout)
 const boot = require('..')
 

--- a/test/express.test.js
+++ b/test/express.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('tap')
 const express = require('express')
-const http = require('http')
+const http = require('node:http')
 const boot = require('..')
 
 test('express support', (t) => {


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
