### PR TITLE
Fix: use options as function type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,7 @@ declare namespace avvio {
   }
 
   interface Use<I, C = context<I>> {
-    <O>(fn: avvio.Plugin<O, I>, options?: O): C;
+    <O>(fn: avvio.Plugin<O, I>, options?: O | ((server: C) => O)): C;
   }
 
   interface Ready<I, C = context<I>> {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -35,6 +35,18 @@ import * as avvio from "../../";
     server.close;
   });
 
+  app.use(async (server, options) => {},
+    (server) => {
+      server.use;
+      server.after;
+      server.ready;
+      server.on;
+      server.start;
+      server.override;
+      server.onClose;
+      server.close;
+  });
+
   app.after(err => {
     if (err) throw err;
   });
@@ -156,6 +168,18 @@ import * as avvio from "../../";
     server.close;
   });
 
+  app.use(async (server, options) => {},
+    (server) => {
+      server.use;
+      server.after;
+      server.ready;
+      server.on;
+      server.start;
+      server.override;
+      server.onClose;
+      server.close;
+    });
+
   app.after(err => {
     if (err) throw err;
   });
@@ -269,6 +293,14 @@ import * as avvio from "../../";
     server.ready;
     server.typescriptIs;
   });
+
+  app.use(async (server, options) => {},
+   ((server) => {
+      server.use;
+      server.after;
+      server.ready;
+      server.typescriptIs;
+  }));
 
   app.after(err => {
     if (err) throw err;


### PR DESCRIPTION
This change correct the type of `options` argument of the `use` function following this line of code https://github.com/fastify/avvio/blob/4f2e04b3be362c1f77e5b50abc2fbd987565dd44/lib/plugin.js#L77

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Note: tests on my local machine returns a lot of errors but I didn't get the problem, hope it's work in CI