### PR TITLE
chore: remove unused deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
   },
   "dependencies": {
     "@fastify/error": "^3.3.0",
-    "archy": "^1.0.0",
-    "debug": "^4.0.0",
     "fastq": "^1.17.1"
   }
 }


### PR DESCRIPTION
@mcollina 

When you published v8.3.0 you accidently added debug and archy as dependencies.