### PR TITLE
Fix timeout count for nested plugins

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -173,17 +173,16 @@ Boot.prototype._addPlugin = function (pluginFn, opts, isAfter) {
   // we always add plugins to load at the current element
   const current = this._current[0]
 
-  // In case of promises, adjust the timeout
-  if (isAfter && this._lastUsed) {
+  let timeout = this._opts.timeout
+
+  if (!current.loaded && current.timeout > 0) {
+    const delta = Date.now() - current.startTime
     // We need to decrease it by 2ms to make sure the internal timeout
-    // is triggered earlier
-    const delta = Date.now() - current.startTime + 2
-    if (this._lastUsed.timeout > 0 && delta > 0) {
-      this._lastUsed.timeout = this._lastUsed.timeout - delta
-    }
+    // is triggered earlier than the parent
+    timeout = current.timeout - (delta + 2)
   }
 
-  const plugin = new Plugin(fastq(this, this._loadPluginNextTick, 1), pluginFn, opts, isAfter, this._opts.timeout)
+  const plugin = new Plugin(fastq(this, this._loadPluginNextTick, 1), pluginFn, opts, isAfter, timeout)
   this._trackPluginLoading(plugin)
 
   if (current.loaded) {

--- a/boot.js
+++ b/boot.js
@@ -177,9 +177,9 @@ Boot.prototype._addPlugin = function (pluginFn, opts, isAfter) {
 
   if (!current.loaded && current.timeout > 0) {
     const delta = Date.now() - current.startTime
-    // We need to decrease it by 2ms to make sure the internal timeout
+    // We need to decrease it by 3ms to make sure the internal timeout
     // is triggered earlier than the parent
-    timeout = current.timeout - (delta + 2)
+    timeout = current.timeout - (delta + 3)
   }
 
   const plugin = new Plugin(fastq(this, this._loadPluginNextTick, 1), pluginFn, opts, isAfter, timeout)

--- a/test/plugin-timeout-await.test.js
+++ b/test/plugin-timeout-await.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/* eslint no-prototype-builtins: off */
+
+const { test } = require('tap')
+const boot = require('..')
+
+test('do not load', async (t) => {
+  const app = boot({}, { timeout: 10 })
+
+  app.use(first)
+
+  async function first (s, opts) {
+    await s.use(second)
+  }
+
+  async function second (s, opts) {
+    await s.use(third)
+  }
+
+  function third (s, opts) {
+    return new Promise((resolve, reject) => {
+      // no resolve
+    })
+  }
+
+  try {
+    await app.start()
+    t.fail('should throw')
+  } catch (err) {
+    t.equal(err.message, 'Plugin did not start in time: \'third\'. You may have forgotten to call \'done\' function or to resolve a Promise')
+  }
+})


### PR DESCRIPTION
This PR changes avvio to make the error message indicate the correct plugin that timed out.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
