### PR TITLE
Fix typings for expose "close" and  "onClose" 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,8 @@ declare namespace avvio {
       use?: string;
       after?: string;
       ready?: string;
+      close?: string;
+      onClose?: string;
     };
     autostart?: boolean;
   }

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -386,7 +386,7 @@ import * as avvio from "../../";
   const server = { hello: "world" };
   const options = {
     autostart: false,
-    expose: { after: "after", ready: "ready", use: "use" }
+    expose: { after: "after", ready: "ready", use: "use", close: "close", onClose : "onClose" }
   };
   // avvio with server and options
   const app = avvio(server, options);


### PR DESCRIPTION
This PR correct the "expose" config typing by adding "close" and  "onClose" options

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
