### PR TITLE
Get original function name in AVV_ERR_READY_TIMEOUT

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -479,7 +479,7 @@ function callWithCbOrNextTick (func, cb) {
 }
 
 function timeoutCall (func, rootErr, context, cb) {
-  const name = func.name
+  const name = func.unwrappedName ?? func.name
   debug('setting up ready timeout', name, this._opts.timeout)
   let timer = setTimeout(() => {
     debug('timed out', name)
@@ -571,7 +571,9 @@ function encapsulateTwoParam (func, that) {
 }
 
 function encapsulateThreeParam (func, that) {
-  return _encapsulateThreeParam.bind(that)
+  const wrapped = _encapsulateThreeParam.bind(that)
+  wrapped.unwrappedName = func.name
+  return wrapped
   function _encapsulateThreeParam (err, cb) {
     let res
     if (!func) {

--- a/test/on-ready-timeout-await.test.js
+++ b/test/on-ready-timeout-await.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+/* eslint no-prototype-builtins: off */
+
+const { test } = require('tap')
+const boot = require('../boot')
+
+test('onReadyTimeout', async (t) => {
+  const app = boot({}, {
+    timeout: 10, // 10 ms
+    autostart: false
+  })
+
+  app.use(function one (innerApp, opts, next) {
+    t.pass('loaded')
+    innerApp.ready(function readyNoResolve (err, done) {
+      t.notOk(err)
+      t.pass('first ready called')
+      // Do not call done() to timeout
+    })
+    next()
+  })
+
+  await app.start()
+
+  try {
+    await app.ready()
+    t.fail('should throw')
+  } catch (err) {
+    t.equal(err.message, 'Plugin did not start in time: \'readyNoResolve\'. You may have forgotten to call \'done\' function or to resolve a Promise')
+    // And not Plugin did not start in time: 'bound _encapsulateThreeParam'. You may have forgotten to call 'done' function or to resolve a Promise
+  }
+})


### PR DESCRIPTION
I don't really know if it is the right approach neither how to do a proper test case yet. Please advise :)

The main use case is to get a proper name in fastify instead of `bound _encapsulateThreeParam`: 
```
ERROR (32467): Uncaught Exception: A callback for 'onReady' hook timed out. You may have forgotten to call 'done' function or to resolve a Promise
    err: {
      "type": "FastifyError",
      "message": "A callback for 'onReady' hook timed out. You may have forgotten to call 'done' function or to resolve a Promise: Plugin did not start in time: 'bound _encapsulateThreeParam'. You may have forgotten to call 'done' function or to resolve a Promise",
      "stack":
          FastifyError: A callback for 'onReady' hook timed out. You may have forgotten to call 'done' function or to resolve a Promise
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
