### PR TITLE
fix: expose timeout typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ declare namespace avvio {
       onClose?: string;
     };
     autostart?: boolean;
+    timeout?: number;
   }
 
   interface Plugin<O, I> {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -386,7 +386,8 @@ import * as avvio from "../../";
   const server = { hello: "world" };
   const options = {
     autostart: false,
-    expose: { after: "after", ready: "ready", use: "use", close: "close", onClose : "onClose" }
+    expose: { after: "after", ready: "ready", use: "use", close: "close", onClose : "onClose" },
+    timeout: 50000
   };
   // avvio with server and options
   const app = avvio(server, options);


### PR DESCRIPTION
Updated `avvio.Options` typings to include the (optional) `timeout` field, documented [here](https://github.com/fastify/avvio?tab=readme-ov-file#avvioinstance-options-started).

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
