### PR TITLE
fix(type): expose timeout typing (#263)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ declare namespace avvio {
       onClose?: string;
     };
     autostart?: boolean;
+    timeout?: number;
   }
 
   interface Plugin<O, I> {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -386,7 +386,8 @@ import * as avvio from "../../";
   const server = { hello: "world" };
   const options = {
     autostart: false,
-    expose: { after: "after", ready: "ready", use: "use", close: "close", onClose : "onClose" }
+    expose: { after: "after", ready: "ready", use: "use", close: "close", onClose : "onClose" },
+    timeout: 50000
   };
   // avvio with server and options
   const app = avvio(server, options);


### PR DESCRIPTION
backport: https://github.com/fastify/avvio/pull/263 in current release line before shipping a new patch (few commits are not released)