### PR TITLE
chore: remove inherits by migrating to ES6 class syntax

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const fastq = require('fastq')
-const EE = require('node:events').EventEmitter
-const inherits = require('node:util').inherits
+const { EventEmitter } = require('node:events')
 const {
   AVV_ERR_EXPOSE_ALREADY_DEFINED,
   AVV_ERR_CALLBACK_NOT_FN,
@@ -23,429 +22,427 @@ const { isPromiseLike } = require('./lib/is-promise-like')
 const { thenify } = require('./lib/thenify')
 const { executeWithThenable } = require('./lib/execute-with-thenable')
 
-function Boot (server, opts, done) {
-  if (typeof server === 'function' && arguments.length === 1) {
-    done = server
-    opts = {}
-    server = null
-  }
-
-  if (typeof opts === 'function') {
-    done = opts
-    opts = {}
-  }
-
-  opts = opts || {}
-  opts.autostart = opts.autostart !== false
-  opts.timeout = Number(opts.timeout) || 0
-  opts.expose = opts.expose || {}
-
-  if (!new.target) {
-    return new Boot(server, opts, done)
-  }
-
-  this._server = server || this
-  this._opts = opts
-
-  if (server) {
-    this._expose()
-  }
-
-  /**
-   * @type {Array<Plugin>}
-   */
-  this._current = []
-
-  this._error = null
-
-  this._lastUsed = null
-
-  this.setMaxListeners(0)
-
-  if (done) {
-    this.once('start', done)
-  }
-
-  this.started = false
-  this.booted = false
-  this.pluginTree = new TimeTree()
-
-  this._readyQ = fastq(this, callWithCbOrNextTick, 1)
-  this._readyQ.pause()
-  this._readyQ.drain = () => {
-    this.emit('start')
-    // nooping this, we want to emit start only once
-    this._readyQ.drain = noop
-  }
-
-  this._closeQ = fastq(this, closeWithCbOrNextTick, 1)
-  this._closeQ.pause()
-  this._closeQ.drain = () => {
-    this.emit('close')
-    // nooping this, we want to emit close only once
-    this._closeQ.drain = noop
-  }
-
-  this._doStart = null
-
-  const instance = this
-  this._root = new Plugin(fastq(this, this._loadPluginNextTick, 1), function root (server, opts, done) {
-    instance._doStart = done
-    opts.autostart && instance.start()
-  }, opts, false, 0)
-
-  this._trackPluginLoading(this._root)
-
-  this._loadPlugin(this._root, (err) => {
-    debug('root plugin ready')
-    try {
-      this.emit('preReady')
-      this._root = null
-    } catch (preReadyError) {
-      err = err || this._error || preReadyError
+class _Boot extends EventEmitter {
+  constructor (server, opts, done) {
+    if (typeof server === 'function' && arguments.length === 1) {
+      done = server
+      opts = {}
+      server = null
     }
 
-    if (err) {
-      this._error = err
-      if (this._readyQ.length() === 0) {
-        throw err
+    if (typeof opts === 'function') {
+      done = opts
+      opts = {}
+    }
+
+    opts = opts || {}
+    opts.autostart = opts.autostart !== false
+    opts.timeout = Number(opts.timeout) || 0
+    opts.expose = opts.expose || {}
+
+    super()
+
+    this._server = server || this
+    this._opts = opts
+
+    if (server) {
+      this._expose()
+    }
+
+    /**
+     * @type {Array<Plugin>}
+     */
+    this._current = []
+
+    this._error = null
+
+    this._lastUsed = null
+
+    this.setMaxListeners(0)
+
+    if (done) {
+      this.once('start', done)
+    }
+
+    this.started = false
+    this.booted = false
+    this.pluginTree = new TimeTree()
+
+    this._readyQ = fastq(this, callWithCbOrNextTick, 1)
+    this._readyQ.pause()
+    this._readyQ.drain = () => {
+      this.emit('start')
+      // nooping this, we want to emit start only once
+      this._readyQ.drain = noop
+    }
+
+    this._closeQ = fastq(this, closeWithCbOrNextTick, 1)
+    this._closeQ.pause()
+    this._closeQ.drain = () => {
+      this.emit('close')
+      // nooping this, we want to emit close only once
+      this._closeQ.drain = noop
+    }
+
+    this._doStart = null
+
+    const instance = this
+    this._root = new Plugin(fastq(this, this._loadPluginNextTick, 1), function root (server, opts, done) {
+      instance._doStart = done
+      opts.autostart && instance.start()
+    }, opts, false, 0)
+
+    this._trackPluginLoading(this._root)
+
+    this._loadPlugin(this._root, (err) => {
+      debug('root plugin ready')
+      try {
+        this.emit('preReady')
+        this._root = null
+      } catch (preReadyError) {
+        err = err || this._error || preReadyError
       }
-    } else {
-      this.booted = true
-    }
-    this._readyQ.resume()
-  })
-}
 
-inherits(Boot, EE)
-
-Boot.prototype.start = function () {
-  this.started = true
-
-  // we need to wait any call to use() to happen
-  process.nextTick(this._doStart)
-  return this
-}
-
-// allows to override the instance of a server, given a plugin
-Boot.prototype.override = function (server, func, opts) {
-  return server
-}
-
-Boot.prototype[kAvvio] = true
-
-// load a plugin
-Boot.prototype.use = function (plugin, opts) {
-  this._lastUsed = this._addPlugin(plugin, opts, false)
-  return this
-}
-
-Boot.prototype._loadRegistered = function () {
-  const plugin = this._current[0]
-  const weNeedToStart = !this.started && !this.booted
-
-  // if the root plugin is not loaded, let's resume that
-  // so one can use after() before calling ready
-  if (weNeedToStart) {
-    process.nextTick(() => this._root.queue.resume())
+      if (err) {
+        this._error = err
+        if (this._readyQ.length() === 0) {
+          throw err
+        }
+      } else {
+        this.booted = true
+      }
+      this._readyQ.resume()
+    })
   }
 
-  if (!plugin) {
-    return Promise.resolve()
-  }
+  start () {
+    this.started = true
 
-  return plugin.loadedSoFar()
-}
-
-Object.defineProperty(Boot.prototype, 'then', { get: thenify })
-
-Boot.prototype._addPlugin = function (pluginFn, opts, isAfter) {
-  if (isBundledOrTypescriptPlugin(pluginFn)) {
-    pluginFn = pluginFn.default
-  }
-  validatePlugin(pluginFn)
-  opts = opts || {}
-
-  if (this.booted) {
-    throw new AVV_ERR_ROOT_PLG_BOOTED()
-  }
-
-  // we always add plugins to load at the current element
-  const current = this._current[0]
-
-  let timeout = this._opts.timeout
-
-  if (!current.loaded && current.timeout > 0) {
-    const delta = Date.now() - current.startTime
-    // We need to decrease it by 3ms to make sure the internal timeout
-    // is triggered earlier than the parent
-    timeout = current.timeout - (delta + 3)
-  }
-
-  const plugin = new Plugin(fastq(this, this._loadPluginNextTick, 1), pluginFn, opts, isAfter, timeout)
-  this._trackPluginLoading(plugin)
-
-  if (current.loaded) {
-    throw new Error(plugin.name, current.name)
-  }
-
-  // we add the plugin to be loaded at the end of the current queue
-  current.enqueue(plugin, (err) => { err && (this._error = err) })
-
-  return plugin
-}
-
-Boot.prototype._expose = function _expose () {
-  const instance = this
-  const server = instance._server
-  const {
-    use: useKey = 'use',
-    after: afterKey = 'after',
-    ready: readyKey = 'ready',
-    onClose: onCloseKey = 'onClose',
-    close: closeKey = 'close'
-  } = this._opts.expose
-
-  if (server[useKey]) {
-    throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(useKey, 'use')
-  }
-  server[useKey] = function (fn, opts) {
-    instance.use(fn, opts)
+    // we need to wait any call to use() to happen
+    process.nextTick(this._doStart)
     return this
   }
 
-  if (server[afterKey]) {
-    throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(afterKey, 'after')
+  // allows to override the instance of a server, given a plugin
+  override (server, func, opts) {
+    return server
   }
-  server[afterKey] = function (func) {
-    if (typeof func !== 'function') {
-      return instance._loadRegistered()
-    }
-    instance.after(encapsulateThreeParam(func, this))
+
+  [kAvvio] = true
+
+  // load a plugin
+  use (plugin, opts) {
+    this._lastUsed = this._addPlugin(plugin, opts, false)
     return this
   }
 
-  if (server[readyKey]) {
-    throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(readyKey, 'ready')
-  }
-  server[readyKey] = function (func) {
-    if (func && typeof func !== 'function') {
-      throw new AVV_ERR_CALLBACK_NOT_FN(readyKey, typeof func)
-    }
-    return instance.ready(func ? encapsulateThreeParam(func, this) : undefined)
-  }
+  _loadRegistered () {
+    const plugin = this._current[0]
+    const weNeedToStart = !this.started && !this.booted
 
-  if (server[onCloseKey]) {
-    throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(onCloseKey, 'onClose')
-  }
-  server[onCloseKey] = function (func) {
-    if (typeof func !== 'function') {
-      throw new AVV_ERR_CALLBACK_NOT_FN(onCloseKey, typeof func)
-    }
-    instance.onClose(encapsulateTwoParam(func, this))
-    return this
-  }
-
-  if (server[closeKey]) {
-    throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(closeKey, 'close')
-  }
-  server[closeKey] = function (func) {
-    if (func && typeof func !== 'function') {
-      throw new AVV_ERR_CALLBACK_NOT_FN(closeKey, typeof func)
+    // if the root plugin is not loaded, let's resume that
+    // so one can use after() before calling ready
+    if (weNeedToStart) {
+      process.nextTick(() => this._root.queue.resume())
     }
 
-    if (func) {
-      instance.close(encapsulateThreeParam(func, this))
+    if (!plugin) {
+      return Promise.resolve()
+    }
+
+    return plugin.loadedSoFar()
+  }
+
+  _addPlugin (pluginFn, opts, isAfter) {
+    if (isBundledOrTypescriptPlugin(pluginFn)) {
+      pluginFn = pluginFn.default
+    }
+    validatePlugin(pluginFn)
+    opts = opts || {}
+
+    if (this.booted) {
+      throw new AVV_ERR_ROOT_PLG_BOOTED()
+    }
+
+    // we always add plugins to load at the current element
+    const current = this._current[0]
+
+    let timeout = this._opts.timeout
+
+    if (!current.loaded && current.timeout > 0) {
+      const delta = Date.now() - current.startTime
+      // We need to decrease it by 3ms to make sure the internal timeout
+      // is triggered earlier than the parent
+      timeout = current.timeout - (delta + 3)
+    }
+
+    const plugin = new Plugin(fastq(this, this._loadPluginNextTick, 1), pluginFn, opts, isAfter, timeout)
+    this._trackPluginLoading(plugin)
+
+    if (current.loaded) {
+      throw new Error(plugin.name, current.name)
+    }
+
+    // we add the plugin to be loaded at the end of the current queue
+    current.enqueue(plugin, (err) => { err && (this._error = err) })
+
+    return plugin
+  }
+
+  _expose () {
+    const instance = this
+    const server = instance._server
+    const {
+      use: useKey = 'use',
+      after: afterKey = 'after',
+      ready: readyKey = 'ready',
+      onClose: onCloseKey = 'onClose',
+      close: closeKey = 'close'
+    } = this._opts.expose
+
+    if (server[useKey]) {
+      throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(useKey, 'use')
+    }
+    server[useKey] = function (fn, opts) {
+      instance.use(fn, opts)
       return this
     }
 
-    // this is a Promise
-    return instance.close()
-  }
-
-  if (server.then) {
-    throw new AVV_ERR_ATTRIBUTE_ALREADY_DEFINED('then')
-  }
-  Object.defineProperty(server, 'then', { get: thenify.bind(instance) })
-
-  server[kAvvio] = true
-}
-
-Boot.prototype.after = function (func) {
-  if (!func) {
-    return this._loadRegistered()
-  }
-
-  this._addPlugin(_after.bind(this), {}, true)
-
-  function _after (s, opts, done) {
-    callWithCbOrNextTick.call(this, func, done)
-  }
-
-  return this
-}
-
-Boot.prototype.onClose = function (func) {
-  // this is used to distinguish between onClose and close handlers
-  // because they share the same queue but must be called with different signatures
-
-  if (typeof func !== 'function') {
-    throw new AVV_ERR_CALLBACK_NOT_FN('onClose', typeof func)
-  }
-
-  func[kIsOnCloseHandler] = true
-  this._closeQ.unshift(func, (err) => { err && (this._error = err) })
-
-  return this
-}
-
-Boot.prototype.close = function (func) {
-  let promise
-
-  if (func) {
-    if (typeof func !== 'function') {
-      throw new AVV_ERR_CALLBACK_NOT_FN('close', typeof func)
+    if (server[afterKey]) {
+      throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(afterKey, 'after')
     }
-  } else {
-    promise = new Promise(function (resolve, reject) {
-      func = function (err) {
-        if (err) {
-          return reject(err)
+    server[afterKey] = function (func) {
+      if (typeof func !== 'function') {
+        return instance._loadRegistered()
+      }
+      instance.after(encapsulateThreeParam(func, this))
+      return this
+    }
+
+    if (server[readyKey]) {
+      throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(readyKey, 'ready')
+    }
+    server[readyKey] = function (func) {
+      if (func && typeof func !== 'function') {
+        throw new AVV_ERR_CALLBACK_NOT_FN(readyKey, typeof func)
+      }
+      return instance.ready(func ? encapsulateThreeParam(func, this) : undefined)
+    }
+
+    if (server[onCloseKey]) {
+      throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(onCloseKey, 'onClose')
+    }
+    server[onCloseKey] = function (func) {
+      if (typeof func !== 'function') {
+        throw new AVV_ERR_CALLBACK_NOT_FN(onCloseKey, typeof func)
+      }
+      instance.onClose(encapsulateTwoParam(func, this))
+      return this
+    }
+
+    if (server[closeKey]) {
+      throw new AVV_ERR_EXPOSE_ALREADY_DEFINED(closeKey, 'close')
+    }
+    server[closeKey] = function (func) {
+      if (func && typeof func !== 'function') {
+        throw new AVV_ERR_CALLBACK_NOT_FN(closeKey, typeof func)
+      }
+
+      if (func) {
+        instance.close(encapsulateThreeParam(func, this))
+        return this
+      }
+
+      // this is a Promise
+      return instance.close()
+    }
+
+    if (server.then) {
+      throw new AVV_ERR_ATTRIBUTE_ALREADY_DEFINED('then')
+    }
+    Object.defineProperty(server, 'then', { get: thenify.bind(instance) })
+
+    server[kAvvio] = true
+  }
+
+  after (func) {
+    if (!func) {
+      return this._loadRegistered()
+    }
+
+    this._addPlugin(_after.bind(this), {}, true)
+
+    function _after (s, opts, done) {
+      callWithCbOrNextTick.call(this, func, done)
+    }
+
+    return this
+  }
+
+  onClose (func) {
+    // this is used to distinguish between onClose and close handlers
+    // because they share the same queue but must be called with different signatures
+
+    if (typeof func !== 'function') {
+      throw new AVV_ERR_CALLBACK_NOT_FN('onClose', typeof func)
+    }
+
+    func[kIsOnCloseHandler] = true
+    this._closeQ.unshift(func, (err) => { err && (this._error = err) })
+
+    return this
+  }
+
+  close (func) {
+    let promise
+
+    if (func) {
+      if (typeof func !== 'function') {
+        throw new AVV_ERR_CALLBACK_NOT_FN('close', typeof func)
+      }
+    } else {
+      promise = new Promise(function (resolve, reject) {
+        func = function (err) {
+          if (err) {
+            return reject(err)
+          }
+          resolve()
         }
-        resolve()
+      })
+    }
+
+    this.ready(() => {
+      this._error = null
+      this._closeQ.push(func)
+      process.nextTick(this._closeQ.resume.bind(this._closeQ))
+    })
+
+    return promise
+  }
+
+  ready (func) {
+    if (func) {
+      if (typeof func !== 'function') {
+        throw new AVV_ERR_CALLBACK_NOT_FN('ready', typeof func)
+      }
+      this._readyQ.push(func)
+      queueMicrotask(this.start.bind(this))
+      return
+    }
+
+    return new Promise((resolve, reject) => {
+      this._readyQ.push(readyPromiseCB)
+      this.start()
+
+      /**
+       * The `encapsulateThreeParam` let callback function
+       * bind to the right server instance.
+       * In promises we need to track the last server
+       * instance loaded, the first one in the _current queue.
+       */
+      const relativeContext = this._current[0].server
+
+      function readyPromiseCB (err, context, done) {
+        // the context is always binded to the root server
+        if (err) {
+          reject(err)
+        } else {
+          resolve(relativeContext)
+        }
+        process.nextTick(done)
       }
     })
   }
 
-  this.ready(() => {
-    this._error = null
-    this._closeQ.push(func)
-    process.nextTick(this._closeQ.resume.bind(this._closeQ))
-  })
-
-  return promise
-}
-
-Boot.prototype.ready = function (func) {
-  if (func) {
-    if (typeof func !== 'function') {
-      throw new AVV_ERR_CALLBACK_NOT_FN('ready', typeof func)
-    }
-    this._readyQ.push(func)
-    queueMicrotask(this.start.bind(this))
-    return
-  }
-
-  return new Promise((resolve, reject) => {
-    this._readyQ.push(readyPromiseCB)
-    this.start()
-
-    /**
-     * The `encapsulateThreeParam` let callback function
-     * bind to the right server instance.
-     * In promises we need to track the last server
-     * instance loaded, the first one in the _current queue.
-     */
-    const relativeContext = this._current[0].server
-
-    function readyPromiseCB (err, context, done) {
-      // the context is always binded to the root server
-      if (err) {
-        reject(err)
-      } else {
-        resolve(relativeContext)
-      }
-      process.nextTick(done)
-    }
-  })
-}
-
-/**
- * @param {Plugin} plugin
- * @returns {void}
- */
-Boot.prototype._trackPluginLoading = function (plugin) {
-  const parentName = this._current[0]?.name || null
-  plugin.once('start', (serverName, funcName, time) => {
-    const nodeId = this.pluginTree.start(parentName || null, funcName, time)
-    plugin.once('loaded', (serverName, funcName, time) => {
-      this.pluginTree.stop(nodeId, time)
-    })
-  })
-}
-
-Boot.prototype.prettyPrint = function () {
-  return this.pluginTree.prettyPrint()
-}
-
-Boot.prototype.toJSON = function () {
-  return this.pluginTree.toJSON()
-}
-
-/**
- * @callback LoadPluginCallback
- * @param {Error} [err]
- */
-
-/**
- * Load a plugin
- *
- * @param {Plugin} plugin
- * @param {LoadPluginCallback} callback
- */
-Boot.prototype._loadPlugin = function (plugin, callback) {
-  const instance = this
-  if (isPromiseLike(plugin.func)) {
-    plugin.func.then((fn) => {
-      if (typeof fn.default === 'function') {
-        fn = fn.default
-      }
-      plugin.func = fn
-      this._loadPlugin(plugin, callback)
-    }, callback)
-    return
-  }
-
-  const last = instance._current[0]
-
-  // place the plugin at the top of _current
-  instance._current.unshift(plugin)
-
-  if (instance._error && !plugin.isAfter) {
-    debug('skipping loading of plugin as instance errored and it is not an after', plugin.name)
-    process.nextTick(execCallback)
-    return
-  }
-
-  let server = (last && last.server) || instance._server
-
-  if (!plugin.isAfter) {
-    // Skip override for after
-    try {
-      server = instance.override(server, plugin.func, plugin.options)
-    } catch (overrideErr) {
-      debug('override errored', plugin.name)
-      return execCallback(overrideErr)
-    }
-  }
-
-  plugin.exec(server, execCallback)
-
-  function execCallback (err) {
-    plugin.finish(err, (err) => {
-      instance._current.shift()
-      callback(err)
+  /**
+   * @param {Plugin} plugin
+   * @returns {void}
+   */
+  _trackPluginLoading = function (plugin) {
+    const parentName = this._current[0]?.name || null
+    plugin.once('start', (serverName, funcName, time) => {
+      const nodeId = this.pluginTree.start(parentName || null, funcName, time)
+      plugin.once('loaded', (serverName, funcName, time) => {
+        this.pluginTree.stop(nodeId, time)
+      })
     })
   }
+
+  prettyPrint () {
+    return this.pluginTree.prettyPrint()
+  }
+
+  toJSON () {
+    return this.pluginTree.toJSON()
+  }
+
+  /**
+   * @callback LoadPluginCallback
+   * @param {Error} [err]
+   */
+
+  /**
+   * Load a plugin
+   *
+   * @param {Plugin} plugin
+   * @param {LoadPluginCallback} callback
+   */
+  _loadPlugin (plugin, callback) {
+    const instance = this
+    if (isPromiseLike(plugin.func)) {
+      plugin.func.then((fn) => {
+        if (typeof fn.default === 'function') {
+          fn = fn.default
+        }
+        plugin.func = fn
+        this._loadPlugin(plugin, callback)
+      }, callback)
+      return
+    }
+
+    const last = instance._current[0]
+
+    // place the plugin at the top of _current
+    instance._current.unshift(plugin)
+
+    if (instance._error && !plugin.isAfter) {
+      debug('skipping loading of plugin as instance errored and it is not an after', plugin.name)
+      process.nextTick(execCallback)
+      return
+    }
+
+    let server = (last && last.server) || instance._server
+
+    if (!plugin.isAfter) {
+      // Skip override for after
+      try {
+        server = instance.override(server, plugin.func, plugin.options)
+      } catch (overrideErr) {
+        debug('override errored', plugin.name)
+        return execCallback(overrideErr)
+      }
+    }
+
+    plugin.exec(server, execCallback)
+
+    function execCallback (err) {
+      plugin.finish(err, (err) => {
+        instance._current.shift()
+        callback(err)
+      })
+    }
+  }
+
+  /**
+   * Delays plugin loading until the next tick to ensure any bound `_after` callbacks have a chance
+   * to run prior to executing the next plugin
+   */
+  _loadPluginNextTick (plugin, callback) {
+    process.nextTick(this._loadPlugin.bind(this), plugin, callback)
+  }
 }
 
-/**
-* Delays plugin loading until the next tick to ensure any bound `_after` callbacks have a chance
-* to run prior to executing the next plugin
-*/
-Boot.prototype._loadPluginNextTick = function (plugin, callback) {
-  process.nextTick(this._loadPlugin.bind(this), plugin, callback)
-}
+Object.defineProperty(_Boot.prototype, 'then', { get: thenify })
 
 function noop () { }
 
@@ -602,6 +599,10 @@ function encapsulateThreeParam (func, that) {
       func(err, this, cb)
     }
   }
+}
+
+function Boot (...args) {
+  return new _Boot(...args)
 }
 
 module.exports = Boot

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,275 +1,276 @@
 'use strict'
 
 const { EventEmitter } = require('node:events')
-const { inherits } = require('node:util')
 const { debug } = require('./debug')
 const { createPromise } = require('./create-promise')
 const { AVV_ERR_PLUGIN_EXEC_TIMEOUT } = require('./errors')
 const { getPluginName } = require('./get-plugin-name')
 const { isPromiseLike } = require('./is-promise-like')
 
-/**
- * @param {*} queue
- * @param {*} func
- * @param {*} options
- * @param {boolean} isAfter
- * @param {number} [timeout]
- */
-function Plugin (queue, func, options, isAfter, timeout) {
-  this.queue = queue
-  this.func = func
-  this.options = options
-
+class Plugin extends EventEmitter {
   /**
-   * @type {boolean}
+   * @param {*} queue
+   * @param {*} func
+   * @param {*} options
+   * @param {boolean} isAfter
+   * @param {number} [timeout]
    */
-  this.isAfter = isAfter
-  /**
-   * @type {number}
-   */
-  this.timeout = timeout
+  constructor (queue, func, options, isAfter, timeout) {
+    super()
 
-  /**
-   * @type {boolean}
-   */
-  this.started = false
-  /**
-   * @type {string}
-   */
-  this.name = getPluginName(func, options)
+    this.queue = queue
+    this.func = func
+    this.options = options
 
-  this.queue.pause()
+    /**
+     * @type {boolean}
+     */
+    this.isAfter = isAfter
+    /**
+     * @type {number}
+     */
+    this.timeout = timeout
 
-  /**
-   * @type {Error|null}
-   */
-  this._error = null
-  /**
-   * @type {boolean}
-   */
-  this.loaded = false
+    /**
+     * @type {boolean}
+     */
+    this.started = false
+    /**
+     * @type {string}
+     */
+    this.name = getPluginName(func, options)
 
-  this._promise = null
+    this.queue.pause()
 
-  this.startTime = null
-}
+    /**
+     * @type {Error|null}
+     */
+    this._error = null
+    /**
+     * @type {boolean}
+     */
+    this.loaded = false
 
-inherits(Plugin, EventEmitter)
+    this._promise = null
 
-/**
- * @callback ExecCallback
- * @param {Error|null} execErr
- * @returns
- */
-
-/**
- *
- * @param {*} server
- * @param {ExecCallback} callback
- * @returns
- */
-Plugin.prototype.exec = function (server, callback) {
-  debug('exec', this.name)
-
-  this.server = server
-  const func = this.func
-  const name = this.name
-  let completed = false
-
-  this.options = typeof this.options === 'function' ? this.options(this.server) : this.options
-
-  let timer = null
-
-  /**
-   * @param {Error} [execErr]
-   */
-  const done = (execErr) => {
-    if (completed) {
-      debug('loading complete', name)
-      return
-    }
-
-    this._error = execErr
-
-    if (execErr) {
-      debug('exec errored', name)
-    } else {
-      debug('exec completed', name)
-    }
-
-    completed = true
-
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    callback(execErr)
+    this.startTime = null
   }
 
-  if (this.timeout > 0) {
-    debug('setting up timeout', name, this.timeout)
-    timer = setTimeout(function () {
-      debug('timed out', name)
-      timer = null
-      const readyTimeoutErr = new AVV_ERR_PLUGIN_EXEC_TIMEOUT(name)
-      // TODO Remove reference to function
-      readyTimeoutErr.fn = func
-      done(readyTimeoutErr)
-    }, this.timeout)
-  }
+  /**
+   * @callback ExecCallback
+   * @param {Error|null} execErr
+   * @returns
+   */
 
-  this.started = true
-  this.startTime = Date.now()
-  this.emit('start', this.server ? this.server.name : null, this.name, Date.now())
+  /**
+   *
+   * @param {*} server
+   * @param {ExecCallback} callback
+   * @returns
+   */
+  exec (server, callback) {
+    debug('exec', this.name)
 
-  const maybePromiseLike = func(this.server, this.options, done)
+    this.server = server
+    const func = this.func
+    const name = this.name
+    let completed = false
 
-  if (isPromiseLike(maybePromiseLike)) {
-    debug('exec: resolving promise', name)
+    this.options = typeof this.options === 'function' ? this.options(this.server) : this.options
 
-    maybePromiseLike.then(
-      () => process.nextTick(done),
-      (e) => process.nextTick(done, e))
-  } else if (func.length < 3) {
-    done()
-  }
-}
+    let timer = null
 
-/**
- * @returns {Promise}
- */
-Plugin.prototype.loadedSoFar = function () {
-  debug('loadedSoFar', this.name)
-
-  if (this.loaded) {
-    return Promise.resolve()
-  }
-
-  const setup = () => {
-    this.server.after((afterErr, callback) => {
-      this._error = afterErr
-      this.queue.pause()
-
-      if (this._promise) {
-        if (afterErr) {
-          debug('rejecting promise', this.name, afterErr)
-          this._promise.reject(afterErr)
-        } else {
-          debug('resolving promise', this.name)
-          this._promise.resolve()
-        }
-        this._promise = null
+    /**
+     * @param {Error} [execErr]
+     */
+    const done = (execErr) => {
+      if (completed) {
+        debug('loading complete', name)
+        return
       }
 
-      process.nextTick(callback, afterErr)
-    })
-    this.queue.resume()
-  }
+      this._error = execErr
 
-  let res
+      if (execErr) {
+        debug('exec errored', name)
+      } else {
+        debug('exec completed', name)
+      }
 
-  if (!this._promise) {
-    this._promise = createPromise()
-    res = this._promise.promise
+      completed = true
 
-    if (!this.server) {
-      this.on('start', setup)
-    } else {
-      setup()
+      if (timer) {
+        clearTimeout(timer)
+      }
+
+      callback(execErr)
     }
-  } else {
-    res = Promise.resolve()
+
+    if (this.timeout > 0) {
+      debug('setting up timeout', name, this.timeout)
+      timer = setTimeout(function () {
+        debug('timed out', name)
+        timer = null
+        const readyTimeoutErr = new AVV_ERR_PLUGIN_EXEC_TIMEOUT(name)
+        // TODO Remove reference to function
+        readyTimeoutErr.fn = func
+        done(readyTimeoutErr)
+      }, this.timeout)
+    }
+
+    this.started = true
+    this.startTime = Date.now()
+    this.emit('start', this.server ? this.server.name : null, this.name, Date.now())
+
+    const maybePromiseLike = func(this.server, this.options, done)
+
+    if (isPromiseLike(maybePromiseLike)) {
+      debug('exec: resolving promise', name)
+
+      maybePromiseLike.then(
+        () => process.nextTick(done),
+        (e) => process.nextTick(done, e))
+    } else if (func.length < 3) {
+      done()
+    }
   }
 
-  return res
-}
+  /**
+   * @returns {Promise}
+   */
+  loadedSoFar () {
+    debug('loadedSoFar', this.name)
 
-/**
- * @callback EnqueueCallback
- * @param {Error|null} enqueueErr
- * @param {Plugin} result
- */
-
-/**
- *
- * @param {Plugin} plugin
- * @param {EnqueueCallback} callback
- */
-Plugin.prototype.enqueue = function (plugin, callback) {
-  debug('enqueue', this.name, plugin.name)
-
-  this.emit('enqueue', this.server ? this.server.name : null, this.name, Date.now())
-  this.queue.push(plugin, callback)
-}
-
-/**
- * @callback FinishCallback
- * @param {Error|null} finishErr
- * @returns
- */
-/**
- *
- * @param {Error|null} err
- * @param {FinishCallback} callback
- * @returns
- */
-Plugin.prototype.finish = function (err, callback) {
-  debug('finish', this.name, err)
-
-  const done = () => {
     if (this.loaded) {
+      return Promise.resolve()
+    }
+
+    const setup = () => {
+      this.server.after((afterErr, callback) => {
+        this._error = afterErr
+        this.queue.pause()
+
+        if (this._promise) {
+          if (afterErr) {
+            debug('rejecting promise', this.name, afterErr)
+            this._promise.reject(afterErr)
+          } else {
+            debug('resolving promise', this.name)
+            this._promise.resolve()
+          }
+          this._promise = null
+        }
+
+        process.nextTick(callback, afterErr)
+      })
+      this.queue.resume()
+    }
+
+    let res
+
+    if (!this._promise) {
+      this._promise = createPromise()
+      res = this._promise.promise
+
+      if (!this.server) {
+        this.on('start', setup)
+      } else {
+        setup()
+      }
+    } else {
+      res = Promise.resolve()
+    }
+
+    return res
+  }
+
+  /**
+   * @callback EnqueueCallback
+   * @param {Error|null} enqueueErr
+   * @param {Plugin} result
+   */
+
+  /**
+   *
+   * @param {Plugin} plugin
+   * @param {EnqueueCallback} callback
+   */
+  enqueue (plugin, callback) {
+    debug('enqueue', this.name, plugin.name)
+
+    this.emit('enqueue', this.server ? this.server.name : null, this.name, Date.now())
+    this.queue.push(plugin, callback)
+  }
+
+  /**
+   * @callback FinishCallback
+   * @param {Error|null} finishErr
+   * @returns
+   */
+  /**
+   *
+   * @param {Error|null} err
+   * @param {FinishCallback} callback
+   * @returns
+   */
+  finish (err, callback) {
+    debug('finish', this.name, err)
+
+    const done = () => {
+      if (this.loaded) {
+        return
+      }
+
+      debug('loaded', this.name)
+      this.emit('loaded', this.server ? this.server.name : null, this.name, Date.now())
+      this.loaded = true
+
+      callback(err)
+    }
+
+    if (err) {
+      if (this._promise) {
+        this._promise.reject(err)
+        this._promise = null
+      }
+      done()
       return
     }
 
-    debug('loaded', this.name)
-    this.emit('loaded', this.server ? this.server.name : null, this.name, Date.now())
-    this.loaded = true
+    const check = () => {
+      debug('check', this.name, this.queue.length(), this.queue.running(), this._promise)
+      if (this.queue.length() === 0 && this.queue.running() === 0) {
+        if (this._promise) {
+          const wrap = () => {
+            debug('wrap')
+            queueMicrotask(check)
+          }
+          this._promise.resolve()
+          this._promise.promise.then(wrap, wrap)
+          this._promise = null
+        } else {
+          done()
+        }
+      } else {
+        debug('delayed', this.name)
+        // finish when the queue of nested plugins to load is empty
+        this.queue.drain = () => {
+          debug('drain', this.name)
+          this.queue.drain = noop
 
-    callback(err)
-  }
-
-  if (err) {
-    if (this._promise) {
-      this._promise.reject(err)
-      this._promise = null
-    }
-    done()
-    return
-  }
-
-  const check = () => {
-    debug('check', this.name, this.queue.length(), this.queue.running(), this._promise)
-    if (this.queue.length() === 0 && this.queue.running() === 0) {
-      if (this._promise) {
-        const wrap = () => {
-          debug('wrap')
+          // we defer the check, as a safety net for things
+          // that might be scheduled in the loading callback
           queueMicrotask(check)
         }
-        this._promise.resolve()
-        this._promise.promise.then(wrap, wrap)
-        this._promise = null
-      } else {
-        done()
-      }
-    } else {
-      debug('delayed', this.name)
-      // finish when the queue of nested plugins to load is empty
-      this.queue.drain = () => {
-        debug('drain', this.name)
-        this.queue.drain = noop
-
-        // we defer the check, as a safety net for things
-        // that might be scheduled in the loading callback
-        queueMicrotask(check)
       }
     }
+
+    queueMicrotask(check)
+
+    // we start loading the dependents plugins only once
+    // the current level is finished
+    this.queue.resume()
   }
-
-  queueMicrotask(check)
-
-  // we start loading the dependents plugins only once
-  // the current level is finished
-  this.queue.resume()
 }
 
 function noop () {}


### PR DESCRIPTION
Refactor to remove the usage of `util.inherits` in favor of the recommended approach (https://nodejs.org/docs/v22.11.0/api/util.html#utilinheritsconstructor-superconstructor).

Unfortunately, the git diff got a bit confused because of the indentation level change. The PR is mainly an adaptation from one syntax to another, the more opinionated points are:

- This function is needed for not adding any breaking change, we still can create instances with and without the `new` keyword.
```js
function Boot (...args) {
  return new _Boot(...args)
}
```

- Now at a class always being initialized with `new`, this piece of code was removed:
```js
if (!new.target) {
   return new Boot(server, opts, done)
}
```

---

The motivation of this PR is interoperability with an alternative JS runtime. I am trying to execute `avvio` along with an EventEmitter implementation that is ES6 class-based.

---

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
