### PR TITLE
Use borp to run tests

### DIFF
--- a/.borp.yaml
+++ b/.borp.yaml
@@ -1,0 +1,2 @@
+files:
+  - 'test/**/*.test.js'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "borp --reporter=@jsumners/line-reporter",
+    "test:coverage": "c8 borp --reporter=@jsumners/line-reporter",
     "test:typescript": "tsc --project ./test/types/tsconfig.json"
   },
   "precommit": [
@@ -63,7 +64,10 @@
   ],
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
+    "@jsumners/line-reporter": "^1.0.1",
     "@types/node": "^22.0.0",
+    "borp": "^0.19.0",
+    "c8": "^10.1.3",
     "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "tap": "^18.7.1",


### PR DESCRIPTION
Before any of the existing open PRs to convert tests can be merged, we need to convert the test runner to support both `tap` and `node:test` based suites. This PR solves it.