### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events'
+import { EventEmitter } from 'node:events'
 
 declare function avvio (done?: Function): avvio.Avvio<null>
 declare function avvio<I> (


### PR DESCRIPTION
This is a batch PR, so may have some issues. Please review changes.