### PR TITLE
test: migrated tests to node:test

### DIFF
--- a/test/lib/create-promise.test.js
+++ b/test/lib/create-promise.test.js
@@ -1,28 +1,29 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { createPromise } = require('../../lib/create-promise')
 
-test('createPromise() returns an object', (t) => {
+test('createPromise() returns an object', async (t) => {
   t.plan(3)
-  t.type(createPromise(), 'object')
-  t.equal(Array.isArray(createPromise()), false)
-  t.notOk(Array.isArray(createPromise() !== null))
+
+  t.assert.strictEqual(typeof createPromise(), 'object')
+  t.assert.strictEqual(Array.isArray(createPromise()), false)
+  t.assert.notStrictEqual(Array.isArray(createPromise()), null)
 })
 
 test('createPromise() returns an attribute with attribute resolve', (t) => {
   t.plan(1)
-  t.ok('resolve' in createPromise())
+  t.assert.ok('resolve' in createPromise())
 })
 
 test('createPromise() returns an attribute with attribute reject', (t) => {
   t.plan(1)
-  t.ok('reject' in createPromise())
+  t.assert.ok('reject' in createPromise())
 })
 
 test('createPromise() returns an attribute with attribute createPromise', (t) => {
   t.plan(1)
-  t.ok('promise' in createPromise())
+  t.assert.ok('promise' in createPromise())
 })
 
 test('when resolve is called, createPromise attribute is resolved', (t) => {
@@ -31,10 +32,10 @@ test('when resolve is called, createPromise attribute is resolved', (t) => {
 
   p.promise
     .then(() => {
-      t.pass()
+      t.assert.ok('pass')
     })
     .catch(() => {
-      t.fail()
+      t.assert.fail()
     })
   p.resolve()
 })
@@ -45,10 +46,10 @@ test('when reject is called, createPromise attribute is rejected', (t) => {
 
   p.promise
     .then(() => {
-      t.fail()
+      t.assert.fail()
     })
     .catch(() => {
-      t.pass()
+      t.assert.ok('pass')
     })
 
   p.reject()

--- a/test/lib/get-plugin-name.test.js
+++ b/test/lib/get-plugin-name.test.js
@@ -1,33 +1,33 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { getPluginName } = require('../../lib/get-plugin-name')
 const { kPluginMeta } = require('../../lib/symbols')
 
 test('getPluginName of function', (t) => {
   t.plan(1)
 
-  t.equal(getPluginName(function aPlugin () { }), 'aPlugin')
+  t.assert.strictEqual(getPluginName(function aPlugin () { }), 'aPlugin')
 })
 
 test('getPluginName of async function', (t) => {
   t.plan(1)
 
-  t.equal(getPluginName(async function aPlugin () { }), 'aPlugin')
+  t.assert.strictEqual(getPluginName(async function aPlugin () { }), 'aPlugin')
 })
 
 test('getPluginName of arrow function without name', (t) => {
   t.plan(2)
 
-  t.equal(getPluginName(() => { }), '() => { }')
-  t.equal(getPluginName(() => { return 'random' }), '() => { return \'random\' }')
+  t.assert.strictEqual(getPluginName(() => { }), '() => { }')
+  t.assert.strictEqual(getPluginName(() => { return 'random' }), '() => { return \'random\' }')
 })
 
 test('getPluginName of arrow function assigned to variable', (t) => {
   t.plan(1)
 
   const namedArrowFunction = () => { }
-  t.equal(getPluginName(namedArrowFunction), 'namedArrowFunction')
+  t.assert.strictEqual(getPluginName(namedArrowFunction), 'namedArrowFunction')
 })
 
 test("getPluginName based on Symbol 'plugin-meta' /1", (t) => {
@@ -38,7 +38,7 @@ test("getPluginName based on Symbol 'plugin-meta' /1", (t) => {
   }
 
   plugin[kPluginMeta] = {}
-  t.equal(getPluginName(plugin), 'plugin')
+  t.assert.strictEqual(getPluginName(plugin), 'plugin')
 })
 
 test("getPluginName based on Symbol 'plugin-meta' /2", (t) => {
@@ -51,17 +51,17 @@ test("getPluginName based on Symbol 'plugin-meta' /2", (t) => {
   plugin[kPluginMeta] = {
     name: 'fastify-non-existent'
   }
-  t.equal(getPluginName(plugin), 'fastify-non-existent')
+  t.assert.strictEqual(getPluginName(plugin), 'fastify-non-existent')
 })
 
 test('getPluginName if null is provided as options', (t) => {
   t.plan(1)
 
-  t.equal(getPluginName(function a () {}, null), 'a')
+  t.assert.strictEqual(getPluginName(function a () {}, null), 'a')
 })
 
 test('getPluginName if name is provided in options', (t) => {
   t.plan(1)
 
-  t.equal(getPluginName(function defaultName () {}, { name: 'providedName' }), 'providedName')
+  t.assert.strictEqual(getPluginName(function defaultName () {}, { name: 'providedName' }), 'providedName')
 })

--- a/test/lib/is-bundled-or-typescript-plugin.test.js
+++ b/test/lib/is-bundled-or-typescript-plugin.test.js
@@ -1,20 +1,20 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { isBundledOrTypescriptPlugin } = require('../../lib/is-bundled-or-typescript-plugin')
 
 test('isBundledOrTypescriptPlugin', (t) => {
   t.plan(9)
 
-  t.equal(isBundledOrTypescriptPlugin(1), false)
-  t.equal(isBundledOrTypescriptPlugin('function'), false)
-  t.equal(isBundledOrTypescriptPlugin({}), false)
-  t.equal(isBundledOrTypescriptPlugin([]), false)
-  t.equal(isBundledOrTypescriptPlugin(null), false)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin(1), false)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin('function'), false)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin({}), false)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin([]), false)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin(null), false)
 
-  t.equal(isBundledOrTypescriptPlugin(function () {}), false)
-  t.equal(isBundledOrTypescriptPlugin(new Promise((resolve) => resolve)), false)
-  t.equal(isBundledOrTypescriptPlugin(Promise.resolve()), false)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin(function () {}), false)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin(new Promise((resolve) => resolve)), false)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin(Promise.resolve()), false)
 
-  t.equal(isBundledOrTypescriptPlugin({ default: () => {} }), true)
+  t.assert.strictEqual(isBundledOrTypescriptPlugin({ default: () => {} }), true)
 })

--- a/test/lib/is-promise-like.test.js
+++ b/test/lib/is-promise-like.test.js
@@ -1,20 +1,20 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { isPromiseLike } = require('../../lib/is-promise-like')
 
 test('isPromiseLike', (t) => {
   t.plan(9)
 
-  t.equal(isPromiseLike(1), false)
-  t.equal(isPromiseLike('function'), false)
-  t.equal(isPromiseLike({}), false)
-  t.equal(isPromiseLike([]), false)
-  t.equal(isPromiseLike(null), false)
+  t.assert.strictEqual(isPromiseLike(1), false)
+  t.assert.strictEqual(isPromiseLike('function'), false)
+  t.assert.strictEqual(isPromiseLike({}), false)
+  t.assert.strictEqual(isPromiseLike([]), false)
+  t.assert.strictEqual(isPromiseLike(null), false)
 
-  t.equal(isPromiseLike(function () {}), false)
-  t.equal(isPromiseLike(new Promise((resolve) => resolve)), true)
-  t.equal(isPromiseLike(Promise.resolve()), true)
+  t.assert.strictEqual(isPromiseLike(function () {}), false)
+  t.assert.strictEqual(isPromiseLike(new Promise((resolve) => resolve)), true)
+  t.assert.strictEqual(isPromiseLike(Promise.resolve()), true)
 
-  t.equal(isPromiseLike({ then: () => {} }), true)
+  t.assert.strictEqual(isPromiseLike({ then: () => {} }), true)
 })

--- a/test/lib/validate-plugin.test.js
+++ b/test/lib/validate-plugin.test.js
@@ -1,19 +1,19 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { validatePlugin } = require('../../lib/validate-plugin')
 const { AVV_ERR_PLUGIN_NOT_VALID } = require('../../lib/errors')
 
 test('validatePlugin', (t) => {
   t.plan(8)
 
-  t.throws(() => validatePlugin(1), new AVV_ERR_PLUGIN_NOT_VALID('number'))
-  t.throws(() => validatePlugin('function'), new AVV_ERR_PLUGIN_NOT_VALID('string'))
-  t.throws(() => validatePlugin({}), new AVV_ERR_PLUGIN_NOT_VALID('object'))
-  t.throws(() => validatePlugin([]), new AVV_ERR_PLUGIN_NOT_VALID('array'))
-  t.throws(() => validatePlugin(null), new AVV_ERR_PLUGIN_NOT_VALID('null'))
+  t.assert.throws(() => validatePlugin(1), new AVV_ERR_PLUGIN_NOT_VALID('number'))
+  t.assert.throws(() => validatePlugin('function'), new AVV_ERR_PLUGIN_NOT_VALID('string'))
+  t.assert.throws(() => validatePlugin({}), new AVV_ERR_PLUGIN_NOT_VALID('object'))
+  t.assert.throws(() => validatePlugin([]), new AVV_ERR_PLUGIN_NOT_VALID('array'))
+  t.assert.throws(() => validatePlugin(null), new AVV_ERR_PLUGIN_NOT_VALID('null'))
 
-  t.doesNotThrow(() => validatePlugin(function () {}))
-  t.doesNotThrow(() => validatePlugin(new Promise((resolve) => resolve)))
-  t.doesNotThrow(() => validatePlugin(Promise.resolve()))
+  t.assert.doesNotThrow(() => validatePlugin(function () {}))
+  t.assert.doesNotThrow(() => validatePlugin(new Promise((resolve) => resolve)))
+  t.assert.doesNotThrow(() => validatePlugin(Promise.resolve()))
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposals:

- migrated `create-promise.test.js` from `tap` to `node:test` 🔥
- migrated `get-plugin-name.test.js` from `tap` to `node:test` 🔥
- migrated `is-bundled-or-typescript-plugin.test.js` from `tap` to `node:test` 🔥
- migrated `is-promise-like.test.js`  from `tap` to `node:test` 🔥
- migrated `validate-plugin.test.js`  from `tap` to `node:test` 🔥

I have grouped some tests in this PR, since I am very easy to review 😉
