### PR TITLE
test: migrated pretty-print.test.js to tap to node:test

### DIFF
--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test')
 const boot = require('..')
 
-test('pretty print', async t => {
+test('pretty print', (t, done) => {
   t.plan(19)
 
   const app = boot()
@@ -35,22 +35,15 @@ test('pretty print', async t => {
     /^$/
   ]
 
-  await new Promise((resolve) => {
-    app.on('preReady', () => {
-      const print = app.prettyPrint()
-      const lines = print.split('\n')
+  app.on('preReady', () => {
+    const print = app.prettyPrint()
+    const lines = print.split('\n')
 
-      t.assert.strictEqual(lines.length, linesExpected.length)
-      lines.forEach((l, i) => {
-        t.assert.match(l, linesExpected[i])
-      })
-
-      resolve()
+    t.assert.strictEqual(lines.length, linesExpected.length)
+    lines.forEach((l, i) => {
+      t.assert.match(l, linesExpected[i])
     })
-
-    if (typeof app.ready === 'function') {
-      app.ready()
-    }
+    done()
   })
 
   function first (s, opts, done) {

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const boot = require('..')
 
-test('pretty print', t => {
+test('pretty print', async t => {
   t.plan(19)
 
   const app = boot()
@@ -32,17 +32,25 @@ test('pretty print', t => {
     /^├── bound _after \d+ ms$/,
     /^└─┬ duplicate \d+ ms$/,
     /^ {2}└── duplicate \d+ ms$/,
-    ''
+    /^$/
   ]
 
-  app.on('preReady', function show () {
-    const print = app.prettyPrint()
-    const lines = print.split('\n')
+  await new Promise((resolve) => {
+    app.on('preReady', () => {
+      const print = app.prettyPrint()
+      const lines = print.split('\n')
 
-    t.equal(lines.length, linesExpected.length)
-    lines.forEach((l, i) => {
-      t.match(l, linesExpected[i])
+      t.assert.strictEqual(lines.length, linesExpected.length)
+      lines.forEach((l, i) => {
+        t.assert.match(l, linesExpected[i])
+      })
+
+      resolve()
     })
+
+    if (typeof app.ready === 'function') {
+      app.ready()
+    }
   })
 
   function first (s, opts, done) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

- migrated `pretty-print.test.js` from `tap` to `node:test` 🔥
