### PR TITLE
test: migrated after-use-after.test.js to tap to node:test

### DIFF
--- a/test/after-use-after.test.js
+++ b/test/after-use-after.test.js
@@ -1,42 +1,44 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const boot = require('..')
 const app = {}
 
 boot(app)
 
-test('multi after', (t) => {
+test('multi after', async (t) => {
   t.plan(6)
+  const app = {}
+  boot(app)
 
   app.use(function (f, opts, cb) {
     cb()
   }).after(() => {
-    t.pass('this is just called')
+    t.assert.ok('this is just called')
 
     app.use(function (f, opts, cb) {
-      t.pass('this is just called')
+      t.assert.ok('this is just called')
       cb()
     })
   }).after(function () {
-    t.pass('this is just called')
+    t.assert.ok('this is just called')
     app.use(function (f, opts, cb) {
-      t.pass('this is just called')
+      t.assert.ok('this is just called')
       cb()
     })
   }).after(function (err, cb) {
-    t.pass('this is just called')
+    t.assert.ok('this is just called')
     cb(err)
   })
 
-  app.ready().then(() => {
-    t.pass('ready')
+  await app.ready().then(() => {
+    t.assert.ok('ready')
   }).catch(() => {
-    t.fail('this should not be called')
+    t.assert.fail('this should not be called')
   })
 })
 
-test('after grouping - use called after after called', (t) => {
+test('after grouping - use called after after called', async (t) => {
   t.plan(9)
   const app = {}
   boot(app)
@@ -57,16 +59,16 @@ test('after grouping - use called after after called', (t) => {
   }))
 
   app.after(function (err, f, done) {
-    t.error(err)
-    t.equal(f.test, TEST_VALUE)
+    t.assert.ifError(err)
+    t.assert.strictEqual(f.test, TEST_VALUE)
 
     f.test2 = OTHER_TEST_VALUE
     done()
   })
 
   app.use(sO(function (f, options, next) {
-    t.equal(f.test, TEST_VALUE)
-    t.equal(f.test2, OTHER_TEST_VALUE)
+    t.assert.strictEqual(f.test, TEST_VALUE)
+    t.assert.strictEqual(f.test2, OTHER_TEST_VALUE)
 
     f.test3 = NEW_TEST_VALUE
 
@@ -74,17 +76,17 @@ test('after grouping - use called after after called', (t) => {
   }))
 
   app.after(function (err, f, done) {
-    t.error(err)
-    t.equal(f.test, TEST_VALUE)
-    t.equal(f.test2, OTHER_TEST_VALUE)
-    t.equal(f.test3, NEW_TEST_VALUE)
+    t.assert.ifError(err)
+    t.assert.strictEqual(f.test, TEST_VALUE)
+    t.assert.strictEqual(f.test2, OTHER_TEST_VALUE)
+    t.assert.strictEqual(f.test3, NEW_TEST_VALUE)
     done()
   })
 
-  app.ready().then(() => {
-    t.pass('ready')
+  await app.ready().then(() => {
+    t.assert.ok('ready')
   }).catch((e) => {
     console.log(e)
-    t.fail('this should not be called')
+    t.assert.fail('this should not be called')
   })
 })

--- a/test/after-use-after.test.js
+++ b/test/after-use-after.test.js
@@ -39,7 +39,7 @@ test('multi after', async (t) => {
 })
 
 test('after grouping - use called after after called', async (t) => {
-  t.plan(9)
+  t.plan(8)
   const app = {}
   boot(app)
 
@@ -83,10 +83,5 @@ test('after grouping - use called after after called', async (t) => {
     done()
   })
 
-  await app.ready().then(() => {
-    t.assert.ok('ready')
-  }).catch((e) => {
-    console.log(e)
-    t.assert.fail('this should not be called')
-  })
+  await app.ready()
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

- migrated `after-to-after.test.js` from `tap` to `node:test` 🔥

