### PR TITLE
test: migrated expose.test.js to tap to node:test

### DIFF
--- a/test/expose.test.js
+++ b/test/expose.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test, describe } = require('node:test')
 const boot = require('..')
 const { AVV_ERR_EXPOSE_ALREADY_DEFINED, AVV_ERR_ATTRIBUTE_ALREADY_DEFINED } = require('../lib/errors')
 const { kAvvio } = require('../lib/symbols')
@@ -12,7 +12,7 @@ for (const key of ['use', 'after', 'ready', 'onClose', 'close']) {
     const app = {}
     app[key] = () => { }
 
-    t.throws(() => boot(app), new AVV_ERR_EXPOSE_ALREADY_DEFINED(key, key))
+    t.assert.throws(() => boot(app), new AVV_ERR_EXPOSE_ALREADY_DEFINED(key, key))
   })
 
   test('throws if ' + key + ' is already there', (t) => {
@@ -21,7 +21,7 @@ for (const key of ['use', 'after', 'ready', 'onClose', 'close']) {
     const app = {}
     app['cust' + key] = () => { }
 
-    t.throws(() => boot(app, { expose: { [key]: 'cust' + key } }), new AVV_ERR_EXPOSE_ALREADY_DEFINED('cust' + key, key))
+    t.assert.throws(() => boot(app, { expose: { [key]: 'cust' + key } }), new AVV_ERR_EXPOSE_ALREADY_DEFINED('cust' + key, key))
   })
 
   test('support expose for ' + key, (t) => {
@@ -34,8 +34,6 @@ for (const key of ['use', 'after', 'ready', 'onClose', 'close']) {
     boot(app, {
       expose
     })
-
-    t.end()
   })
 }
 
@@ -45,36 +43,34 @@ test('set the kAvvio to true on the server', (t) => {
   const server = {}
   boot(server)
 
-  t.ok(server[kAvvio])
+  t.assert.ok(server[kAvvio])
 })
 
-test('.then()', t => {
-  t.plan(3)
-
-  t.test('.then() can not be overwritten', (t) => {
+describe('.then()', () => {
+  test('.then() can not be overwritten', (t) => {
     t.plan(1)
 
     const server = {
       then: () => {}
     }
-    t.throws(() => boot(server), AVV_ERR_ATTRIBUTE_ALREADY_DEFINED('then'))
+
+    t.assert.throws(() => boot(server), AVV_ERR_ATTRIBUTE_ALREADY_DEFINED('then'))
   })
 
-  t.test('.then() is a function', (t) => {
+  test('.then() is a function', (t) => {
+    t.plan(1)
+
+    const server = {}
+    boot(server)
+    t.assert.strictEqual(typeof server.then, 'function')
+  })
+
+  test('.then() can not be overwritten', (t) => {
     t.plan(1)
 
     const server = {}
     boot(server)
 
-    t.type(server.then, 'function')
-  })
-
-  t.test('.then() can not be overwritten', (t) => {
-    t.plan(1)
-
-    const server = {}
-    boot(server)
-
-    t.throws(() => { server.then = 'invalid' }, TypeError('Cannot set property then of #<Object> which has only a getter'))
+    t.assert.throws(() => { server.then = 'invalid' }, TypeError('Cannot set property then of #<Object> which has only a getter'))
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Proposal:

 - migrated `expose.test.js` from `tap` to `node:test` 🔥