### PR TITLE
chore: removed .taprc file

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,3 +1,0 @@
-allow-incomplete-coverage: true
-files:
-  - test/**/*test.js


### PR DESCRIPTION
Proposal:

- Removed `.taprc` file, because the tests have all been converted with `node:test`