### PR TITLE
chore: remove tests-checker workflow

### DIFF
--- a/.github/tests_checker.yml
+++ b/.github/tests_checker.yml
@@ -1,3 +1,0 @@
-comment: 'Could you please add tests to make sure this change works as expected?',
-fileExtensions: ['.php', '.ts', '.js', '.c', '.cs', '.cpp', '.rb', '.java']
-testDir: 'test'


### PR DESCRIPTION
Proposal:

- Removed `tests_checker.yml` workflow configuration file

The `tests-checker` ( Bot ) action has been deprecated by the maintainers (see https://github.com/infection/tests-checker)

It seems to me that it is not really used during the CI (Continuous Integration) flow.